### PR TITLE
Fix mass selection on local data mode, disable on remote

### DIFF
--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -41,6 +41,7 @@
       <px-demo-component slot="px-demo-component">
         <px-data-grid
           table-data="{{props.tableData.value}}"
+          selectable="{{props.selectable.value}}"
           multi-sort="{{props.multiSort.value}}"
           column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
           action-menu="{{props.actionMenu.value}}"
@@ -498,6 +499,12 @@
           }
         ],
         inputType: 'code:JSON'
+      },
+
+      selectable: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
       },
 
       resizable: {

--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -461,6 +461,16 @@
         type: Array,
         defaultValue: [
           {
+            name: 'Age',
+            path: 'age',
+            type: 'number',
+            width: '50px',
+            flexGrow: 0,
+            value: (item) => {
+              return item.age;
+            }
+          },
+          {
             name: 'Full Name',
             hidden: true,
             path: 'last',
@@ -473,7 +483,7 @@
             path: 'first',
             value: (item) => {
               return item.first;
-            }
+            },
           },
           {
             name: 'Last Name',
@@ -487,14 +497,6 @@
             path: 'email',
             value: (item) => {
               return item.email;
-            }
-          },
-          {
-            name: 'Age',
-            path: 'age',
-            type: 'number',
-            value: (item) => {
-              return item.age;
             }
           }
         ],

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -53,6 +53,7 @@
         <px-data-grid
             table-data="{{props.tableData.value}}"
             selectable="{{props.selectable.value}}"
+            multi-select="{{props.multiSelect.value}}"
             selected-items="{{selectedItems}}"
             hide-selection-column="{{props.hideSelectionColumn.value}}"
             resizable="{{props.resizable.value}}"
@@ -463,6 +464,12 @@
       selectable: {
         type: Boolean,
         defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      multiSelect: {
+        type: Boolean,
+        defaultValue: true,
         inputType: 'toggle'
       },
 

--- a/px-data-grid-column.html
+++ b/px-data-grid-column.html
@@ -122,27 +122,25 @@
           }
         }
 
-        _orderChanged(order, headerCell, footerCell, cells) {
-          if (this.mappedObject && this.mappedObject.order != order) {
-            this.mappedObject.order = order;
-            this._fireStatusChange(this.mappedObject, 'order');
+        _checkIfValueChanged(value, propertyName) {
+          if (this.mappedObject && this.mappedObject[propertyName] != value) {
+            this.mappedObject[propertyName] = value;
+            this._fireStatusChange(this.mappedObject, propertyName);
           }
+        }
+
+        _orderChanged(order, headerCell, footerCell, cells) {
+          this._checkIfValueChanged(order, 'order');
           super._orderChanged(order, headerCell, footerCell, cells);
         }
 
         _frozenChanged(frozen, headerCell, footerCell, cells) {
-          if (this.mappedObject && this.mappedObject.frozen != frozen) {
-            this.mappedObject.frozen = frozen;
-            this._fireStatusChange(this.mappedObject, 'frozen');
-          }
+          this._checkIfValueChanged(frozen, 'frozen');
           super._frozenChanged(frozen, headerCell, footerCell, cells);
         }
 
         _hiddenChanged(hidden, headerCell, footerCell, cells) {
-          if (this.mappedObject && this.mappedObject.hidden != hidden) {
-            this.mappedObject.hidden = hidden;
-            this._fireStatusChange(this.mappedObject, 'hidden');
-          }
+          this._checkIfValueChanged(hidden, 'hidden');
           super._hiddenChanged(hidden, headerCell, footerCell, cells);
         }
 

--- a/px-data-grid-column.html
+++ b/px-data-grid-column.html
@@ -121,6 +121,44 @@
             obj.element = this;
           }
         }
+
+        _orderChanged(order, headerCell, footerCell, cells) {
+          if (this.mappedObject && this.mappedObject.order != order) {
+            this.mappedObject.order = order;
+            this._fireStatusChange(this.mappedObject, 'order');
+          }
+          super._orderChanged(order, headerCell, footerCell, cells);
+        }
+
+        _frozenChanged(frozen, headerCell, footerCell, cells) {
+          if (this.mappedObject && this.mappedObject.frozen != frozen) {
+            this.mappedObject.frozen = frozen;
+            this._fireStatusChange(this.mappedObject, 'frozen');
+          }
+          super._frozenChanged(frozen, headerCell, footerCell, cells);
+        }
+
+        _hiddenChanged(hidden, headerCell, footerCell, cells) {
+          if (this.mappedObject && this.mappedObject.hidden != hidden) {
+            this.mappedObject.hidden = hidden;
+            this._fireStatusChange(this.mappedObject, 'hidden');
+          }
+          super._hiddenChanged(hidden, headerCell, footerCell, cells);
+        }
+
+        _fireStatusChange(mappedObject, value) {
+          this._renderDebouncer = Polymer.Debouncer.debounce(
+            this._renderDebouncer,
+            Polymer.Async.timeOut.after(this.timeout), () => {
+              this.dispatchEvent(new CustomEvent('column-change', {
+                detail: {
+                  column: mappedObject,
+                  type: value
+                },
+                bubbles: true
+              }));
+            });
+        }
       }
 
       customElements.define(DataGridColumnElement.is, DataGridColumnElement);

--- a/px-data-grid-selection-column.html
+++ b/px-data-grid-selection-column.html
@@ -1,0 +1,256 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../vaadin-grid/vaadin-grid-column.html">
+<link rel="import" href="../vaadin-checkbox/vaadin-checkbox.html">
+
+<dom-module id="px-data-grid-selection-column">
+  <template>
+    <template class="header" id="defaultHeaderTemplate">
+      <template is="dom-if" if="[[multiSelect]]">
+        <vaadin-checkbox aria-label="Select All" hidden$="[[_selectAllHidden]]" on-checked-changed="_onSelectAllCheckedChanged"
+          checked="[[_isChecked(selectAll, _indeterminate)]]" indeterminate="[[_indeterminate]]">
+        </vaadin-checkbox>
+      </template>
+    </template>
+    <template id="defaultBodyTemplate">
+      <vaadin-checkbox aria-label="Select Row" aria-label="Select Row" checked="{{selected}}">
+      </vaadin-checkbox>
+    </template>
+  </template>
+
+  <script>
+  {
+    /**
+     * `<px-data-grid-selection-column>` is a helper element for the `<px-data-grid>`
+     * to be used to offer selection column behavior with multi and single select.
+     * @memberof Predix
+     * @mixes Vaadin.GridColumnElement
+     */
+    class DataGridSelectionColumnElement extends Vaadin.GridColumnElement {
+
+      static get is() {
+        return 'px-data-grid-selection-column';
+      }
+
+      static get properties() {
+        return {
+          /**
+           * Width of the cells for this column.
+           */
+          width: {
+            type: String,
+            value: '56px'
+          },
+
+          /**
+           * Flex grow ratio for the cell widths. When set to 0, cell width is fixed.
+           */
+          flexGrow: {
+            type: Number,
+            value: 0
+          },
+
+          /**
+           * When true, all the items are selected.
+           */
+          selectAll: {
+            type: Boolean,
+            value: false,
+            notify: true
+          },
+
+          /**
+           * When true, the active gets automatically selected.
+           */
+          autoSelect: {
+            type: Boolean,
+            value: false,
+          },
+
+          /**
+           * When true, user is allowed to multiselect
+           */
+          multiSelect: {
+            type: Boolean,
+            value: true
+          },
+
+          /**
+          * @private
+          */
+          headerTemplate: Object,
+
+          /**
+          * @private
+          */
+          template: Object,
+
+          _indeterminate: Boolean,
+
+          /*
+           * The previous state of activeItem. When activeItem turns to `null`,
+           * previousActiveItem will have an Object with just unselected activeItem
+           */
+          _previousActiveItem: Object,
+
+          _selectAllHidden: {
+            type: Boolean,
+            value: true
+          }
+        };
+      }
+
+      static get observers() {
+        return [
+          '_onSelectAllChanged(selectAll)'
+        ];
+      }
+
+      _prepareHeaderTemplate() {
+        const headerTemplate = this._prepareTemplatizer(this._findTemplate('template.header') || this.$.defaultHeaderTemplate);
+        // needed to override the dataHost correctly in case internal template is used.
+        headerTemplate.templatizer.dataHost = headerTemplate === this.$.defaultHeaderTemplate ? this : this.dataHost;
+
+        return headerTemplate;
+      }
+
+      _prepareBodyTemplate() {
+        const template = this._prepareTemplatizer(this._findTemplate('template:not(.header):not(.footer)') || this.$.defaultBodyTemplate);
+        // needed to override the dataHost correctly in case internal template is used.
+        template.templatizer.dataHost = template === this.$.defaultBodyTemplate ? this : this.dataHost;
+
+        return template;
+      }
+
+      constructor() {
+        super();
+
+        this._boundOnActiveItemChanged = this._onActiveItemChanged.bind(this);
+        this._boundOnDataProviderChanged = this._onDataProviderChanged.bind(this);
+        this._boundOnSelectedItemsChanged = this._onSelectedItemsChanged.bind(this);
+      }
+
+      ready() {
+        super.ready();
+        if (this._grid && this._grid._pxDataGrid) {
+          this._selectAllHidden = !this._grid._pxDataGrid._hasLocalDataProvider;
+        }
+      }
+
+      /** @private */
+      disconnectedCallback() {
+        super.disconnectedCallback();
+
+        if (this._grid) {
+          this._grid.removeEventListener('active-item-changed', this._boundOnActiveItemChanged);
+          this._grid.removeEventListener('data-provider-changed', this._boundOnDataProviderChanged);
+          this._grid.removeEventListener('filter-changed', this._boundOnSelectedItemsChanged);
+          this._grid.removeEventListener('selected-items-changed', this._boundOnSelectedItemsChanged);
+
+          const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+          if (isSafari && window.ShadyDOM && this.parentElement) {
+            // Detach might have beem caused by order change.
+            // Shady on safari doesn't restore isAttached so we'll need to do it manually.
+            const parent = this.parentElement;
+            const nextSibling = this.nextElementSibling;
+            parent.removeChild(this);
+            if (nextSibling) {
+              parent.insertBefore(this, nextSibling);
+            } else {
+              parent.appendChild(this);
+            }
+          }
+
+        }
+      }
+
+      /** @private */
+      connectedCallback() {
+        super.connectedCallback();
+        if (this._grid) {
+          this._grid.addEventListener('active-item-changed', this._boundOnActiveItemChanged);
+          this._grid.addEventListener('data-provider-changed', this._boundOnDataProviderChanged);
+          this._grid.addEventListener('filter-changed', this._boundOnSelectedItemsChanged);
+          this._grid.addEventListener('selected-items-changed', this._boundOnSelectedItemsChanged);
+
+          if (this._grid._pxDataGrid) {
+            this._selectAllHidden = !this._grid._pxDataGrid._hasLocalDataProvider;
+          }
+        }
+      }
+
+      _onSelectAllChanged(selectAll) {
+        if (selectAll === undefined || !this._grid) {
+          return;
+        }
+
+        if (this._selectAllChangeLock) {
+          return;
+        }
+
+        if (selectAll && this._grid._pxDataGrid) {
+          this._grid.selectedItems = this._grid._pxDataGrid._getAllLocalItems();
+        } else {
+          this._grid.selectedItems = [];
+        }
+      }
+
+      // Return true if array `a` contains all the items in `b`
+      // We need this when sorting or to preserve selection after filtering.
+      _arrayContains(a, b) {
+        for (var i = 0; a && b && b[i] && a.indexOf(b[i]) >= 0; i++); // eslint-disable-line
+        return i == b.length;
+      }
+
+      _onSelectAllCheckedChanged(e) {
+        this.selectAll = this._indeterminate || e.target.checked;
+      }
+
+      // iOS needs indeterminated + checked at the same time
+      _isChecked(selectAll, indeterminate) {
+        return indeterminate || selectAll;
+      }
+
+      _onActiveItemChanged(e) {
+        const activeItem = e.detail.value;
+        if (this.autoSelect) {
+          const item = activeItem || this._previousActiveItem;
+          if (item) {
+            this._grid._toggleItem(item);
+          }
+        }
+        this._previousActiveItem = activeItem;
+      }
+
+      _onSelectedItemsChanged(e) {
+        this._selectAllChangeLock = true;
+        const allItems = this._grid._pxDataGrid._getAllLocalItems();
+        if (Array.isArray(allItems)) {
+          if (!this._grid.selectedItems.length) {
+            this.selectAll = false;
+            this._indeterminate = false;
+          } else if (this._arrayContains(this._grid.selectedItems, allItems)) {
+            this.selectAll = true;
+            this._indeterminate = false;
+          } else {
+            this.selectAll = false;
+            this._indeterminate = true;
+          }
+        }
+        this._selectAllChangeLock = false;
+      }
+
+      _onDataProviderChanged(e) {
+        this._selectAllHidden = !this._grid._pxDataGrid._hasLocalDataProvider;
+      }
+    }
+
+    customElements.define(DataGridSelectionColumnElement.is, DataGridSelectionColumnElement);
+
+    /**
+     * @namespace Predix
+     */
+    window.Predix = window.Predix || {};
+    Predix.DataGridSelectionColumnElement = DataGridSelectionColumnElement;
+  }
+  </script>
+</dom-module>

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -98,7 +98,9 @@
           language="[[language]]"
           resources="[[resources]]"
           type="[[column.type]]"
-          mapped-object="[[column]]">
+          mapped-object="[[column]]"
+          width="[[_getColumnWidth(column)]]"
+          flex-grow="[[_getColumnFlexGrow(column)]]">
           <template class="header">
             <vaadin-grid-sorter path="[[_resolveColumnPath(column)]]">[[_resolveColumnHeader(column)]]</vaadin-grid-sorter>
           </template>
@@ -424,6 +426,22 @@
              */
             _hasLocalDataProvider: {
               type: Boolean
+            },
+
+            /**
+             * Default column width if not defined, eg. '100px'
+             */
+            defaultColumnWidth: {
+              type: String,
+              value: '100px'
+            },
+
+            /**
+             * Default column flex if not defined, eg. 1
+             */
+            defaultColumnFlex: {
+              type: Number,
+              value: 1
             }
           };
         }
@@ -501,6 +519,14 @@
           } else {
             return undefined;
           }
+        }
+
+        _getColumnWidth(column) {
+          return column.width ? column.width : this.defaultColumnWidth;
+        }
+
+        _getColumnFlexGrow(column) {
+          return column.flexGrow === undefined ? this.defaultColumnFlex : column.flexGrow;
         }
 
         _getCellStyle(item, column) {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -67,6 +67,7 @@
           <px-dropdown multi hide-selected
             display-value="[[localize('Table Actions')]]"
             items="[[_actionMenuContent]]"
+            selected-values="[[_selectedActionItems]]"
             disable-clear
             on-px-dropdown-click="_actionClicked">
           </px-dropdown>
@@ -100,7 +101,8 @@
           type="[[column.type]]"
           mapped-object="[[column]]"
           width="[[_getColumnWidth(column)]]"
-          flex-grow="[[_getColumnFlexGrow(column)]]">
+          flex-grow="[[_getColumnFlexGrow(column)]]"
+          on-column-change="_onColumnUpdate">
           <template class="header">
             <vaadin-grid-sorter path="[[_resolveColumnPath(column)]]">[[_resolveColumnHeader(column)]]</vaadin-grid-sorter>
           </template>
@@ -442,6 +444,11 @@
             defaultColumnFlex: {
               type: Number,
               value: 1
+            },
+
+            _selectedActionItems: {
+              type: Array,
+              value: []
             }
           };
         }
@@ -687,8 +694,12 @@
           const item = evt.detail.detail.item;
           const key = item.key;
 
-          if (key.action) {
-            key.action();
+          // -column- is temporary work around to limitations of px-dropdown
+          if (key && key.startsWith('-column-')) {
+            const columnName = key.substr('-column-'.length);
+            this._getColumnsWithName(columnName).forEach((c) => {
+              c.hidden = c.hidden === undefined ? true : !c.hidden;
+            });
           }
         }
 
@@ -713,6 +724,7 @@
          */
         _updateActionMenu() {
           const content = [];
+          this._selectedActionItems = [];
 
           // Application specific options
 
@@ -733,30 +745,39 @@
 
           const defaultName = this.localize('Column #');
           let counter = 0;
+          const selected = [];
 
           this._getColumns().forEach((columnElement) => {
             const index = ++counter;
             const hidden = columnElement.hidden ? columnElement.hidden : false;
             const name = columnElement.name ? columnElement.name : (defaultName + index);
+            // -column- is temporary work around to limitations of px-dropdown
+            const key = '-column-' + name;
 
-            content.push({
-              key: {
-                action: () => {
-                  this._getColumnsWithName(name).forEach((c) => {
-                    c.hidden = !(c.hidden ? c.hidden : false);
-                  });
-                }
-              },
-              val: name,
-              selected: !hidden
-            });
+            const item = {
+              key: key,
+              val: name
+            };
+
+            if (!hidden) {
+              selected.push(key);
+            }
+
+            content.push(item);
           });
 
           this._actionMenuContent = content;
+          this._selectedActionItems = selected;
         }
 
         _getColumnsWithName(name) {
           return this._getColumns().filter(c => c.name == name);
+        }
+
+        _onColumnUpdate(event) {
+          if (event.detail.type == 'hidden') {
+            this._updateActionMenu();
+          }
         }
 
         _loadingChanged(loading) {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -7,6 +7,7 @@
 <link rel="import" href="px-auto-filter-field.html">
 <link rel="import" href="px-data-grid-navigation.html">
 <link rel="import" href="px-data-grid-theme.html">
+<link rel="import" href="px-data-grid-selection-column.html">
 <link rel="import" href="../app-localize-behavior/app-localize-behavior.html"/>
 
 <dom-module id="px-data-grid">
@@ -85,8 +86,8 @@
                  loading="{{_loading}}">
 
       <template is="dom-if" if="[[selectable]]" restamp>
-        <vaadin-grid-selection-column auto-select hidden="[[hideSelectionColumn]]">
-        </vaadin-grid-selection-column>
+        <px-data-grid-selection-column auto-select hidden="[[hideSelectionColumn]]" multi-select="[[multiSelect]]">
+        </px-data-grid-selection-column>
       </template>
 
       <template is="dom-repeat" items="[[columns]]" as="column">
@@ -192,6 +193,14 @@
             multiSort: {
               type: Boolean,
               value: false
+            },
+
+            /**
+             * When `true`, selection mode will be multiselection when selectable
+             */
+            multiSelect: {
+              type: Boolean,
+              value: true
             },
 
             /**
@@ -407,6 +416,14 @@
             highlight: {
               type: Array,
               value: []
+            },
+
+            /**
+             * When true data provider is local, when false external (remote) and
+             * when undefined it defined yet.
+             */
+            _hasLocalDataProvider: {
+              type: Boolean
             }
           };
         }
@@ -414,6 +431,10 @@
         ready() {
           super.ready();
           this._vaadinGrid = this.shadowRoot.querySelector('vaadin-grid');
+          this._vaadinGrid._pxDataGrid = this;
+
+          // Override selectItem method to allow easy single select handling
+          this._vaadinGrid.selectItem = (item) => this._handleSelectItem(item);
 
           this.addEventListener('column-froze', (event) => {
             this._vaadinGrid.insertBefore(event.detail.column, this._vaadinGrid.firstElementChild);
@@ -431,6 +452,18 @@
           if (this.highlight.length) {
             this._vaadinGrid.setAttribute('highlighted', '');
             this.setAttribute('highlighted', '');
+          }
+        }
+
+        /**
+         * Trick to prevent multiselection when in single select mode
+         */
+        _handleSelectItem(item) {
+          if (!this._vaadinGrid._isSelected(item)) {
+            if (!this.multiSelect) {
+              this._vaadinGrid.selectedItems = [];
+            }
+            this._vaadinGrid.push('selectedItems', item);
           }
         }
 
@@ -462,7 +495,7 @@
           );
         }
 
-        _readValue(column, item) {
+        _getValue(column, item) {
           if (column && item) {
             return column.value ? column.value(item) : this.get(column.name, item);
           } else {
@@ -497,7 +530,7 @@
                 }
               }
             } else {
-              const value = this._readValue(column, item);
+              const value = this._getValue(column, item);
               if (highlightEntity.condition(value, column, item)) {
                 if (highlightEntity.color) {
                   cellColor = `background: ${highlightEntity.color}`;
@@ -534,22 +567,23 @@
         }
 
         _tableDataChanged(tableData) {
-          this._currentDataProvider = (params, callback) => {
-            this._localDataProvider(params, callback);
-          };
-          this._populateTableColumns(tableData);
+          if (tableData) {
+            this._currentDataProvider = (params, callback) => {
+              this._localDataProvider(params, callback);
+            };
+            this._hasLocalDataProvider = true;
+            this._populateTableColumns(tableData);
+          }
         }
 
-        _localDataProvider(params, callback) {
-          let items = (Array.isArray(this.tableData) ? this.tableData : []).slice(0);
-
+        _localDataResolver(params, items) {
           if (params.filters && params.filters.length && this._vaadinGrid._checkPaths(params.filters, 'filtering', items)) {
             items = this._filter(items, params.filters);
           }
 
           this.size = items.length;
 
-          if (params.sortOrders.length && this._vaadinGrid._checkPaths(this._sorters, 'sorting', items)) {
+          if (params.sortOrders && params.sortOrders.length && this._vaadinGrid._checkPaths(this._sorters, 'sorting', items)) {
             const multiSort = (a, b) => {
               return params.sortOrders.map(sort => {
                 if (sort.direction === 'asc') {
@@ -568,11 +602,33 @@
 
           const start = params.page * params.pageSize;
           const end = start + params.pageSize;
-          const slice = items.slice(start, end);
-          callback(slice, items.length);
+
+          return items.slice(start, end);
+        }
+
+        _localDataProvider(params, callback) {
+          let items = (Array.isArray(this.tableData) ? this.tableData : []).slice(0);
+          items = this._localDataResolver(params, items);
+          callback(items, items.length);
+        }
+
+        /**
+         * Will return all local items after filter (no ordering applied)
+         */
+        _getAllLocalItems() {
+          if (this._hasLocalDataProvider) {
+            const items = (Array.isArray(this.tableData) ? this.tableData : []).slice(0);
+            return this._localDataResolver({
+              page: 0,
+              pageSize: this.tableData.length
+            }, items);
+          } else {
+            return [];
+          }
         }
 
         _remoteDataProviderChanged(provider) {
+          this._hasLocalDataProvider = false;
           this._currentDataProvider = provider;
         }
 
@@ -743,13 +799,6 @@
             this._vaadinGrid._filters = filters;
             this._vaadinGrid.clearCache();
           }
-        }
-
-        _getValue(column, item) {
-          if (!column || !item) {
-            return;
-          }
-          return column.value(item);
         }
 
         /**

--- a/test/px-data-grid-test.js
+++ b/test/px-data-grid-test.js
@@ -1,0 +1,406 @@
+const data = [{
+  'first': 'Elizabeth',
+  'last': 'Wong',
+  'email': 'sika@iknulber.cl'
+}, {
+  'first': 'Jeffrey',
+  'last': 'Hamilton',
+  'email': 'cofok@rac.be'
+}, {
+  'first': 'Alma',
+  'last': 'Martin',
+  'email': 'dotta@behtam.la'
+}, {
+  'first': 'Carl',
+  'last': 'Saunders',
+  'email': 'seh@bibapu.gy'
+}, {
+  'first': 'Willie',
+  'last': 'Dennis',
+  'email': 'izko@dahokwej.ci'
+}];
+
+
+document.addEventListener('WebComponentsReady', function() {
+  runTests();
+});
+
+
+function runTests() {
+
+  describe('Unit Tests for px-data-grid', () => {
+    let grid;
+    let timeoutSpy;
+
+    function getRows() {
+      return grid._vaadinGrid.$.items.querySelectorAll('tr');
+    }
+
+    function getVisibleRows() {
+      // the following querySelector fails on safari for some reason
+      // return grid._vaadinGrid.$.items.querySelectorAll('tr:not([hidden]');
+      const rows = getRows();
+      const visibleRows = Array.prototype.filter.call(rows, function(row) {
+        return row.getAttribute('hidden') !== ''
+            && row.getAttribute('hidden') !== true;
+      });
+      return visibleRows;
+    }
+
+    function getRowCells(row) {
+      return Array.prototype.slice.call(Polymer.dom(row).querySelectorAll('[part~="cell"]'));
+    }
+
+    function flushVaadinGrid() {
+      const vaadinGrid = grid.shadowRoot.querySelector('vaadin-grid');
+      Polymer.flush();
+      vaadinGrid._observer.flush();
+      Polymer.flush();
+      if (vaadinGrid._debounceScrolling) {
+        vaadinGrid._debounceScrolling.flush();
+      }
+      if (vaadinGrid._debounceScrollPeriod) {
+        vaadinGrid._debounceScrollPeriod.flush();
+      }
+      if (vaadinGrid._debouncerLoad) {
+        vaadinGrid._debouncerLoad.flush();
+      }
+    }
+
+    function getCellContent(cell) {
+      const slot = cell.querySelector('slot');
+      const slotName = slot.getAttribute('name');
+      const content = grid.shadowRoot.querySelector('[slot="' + slotName + '"]');
+      const wrapper = content.querySelector('div');
+      return wrapper.innerHTML;
+    }
+
+    function getHeaderCell(grid, index) {
+      return grid._vaadinGrid.$.header.querySelectorAll('[part~="cell"]')[index];
+    }
+
+    function getHeaderCellContent(cell) {
+      return cell ? cell.querySelector('slot').assignedNodes()[0].querySelector('px-data-grid-header-cell') : null;
+    }
+
+    beforeEach((done) => {
+      grid = fixture('simple-grid');
+      grid.tableData = data;
+
+      Polymer.RenderStatus.afterNextRender(grid, () => {
+        setTimeout(() => { // IE11
+          done();
+        });
+      });
+    });
+
+    describe('simple-grid tests', () => {
+      it('should properly populate columns', () => {
+        expect(grid.columns.length).to.be.eql(3);
+        expect(grid.columns[0].name).to.be.eql('first');
+        expect(grid.columns[1].name).to.be.eql('last');
+        expect(grid.columns[2].name).to.be.eql('email');
+      });
+    });
+
+    describe('spinner', () => {
+      function createTimeoutSpy() {
+        timeoutSpy = sinon.spy(window, 'setTimeout');
+
+        grid.remoteDataProvider = () => {};
+
+        const call = timeoutSpy.getCalls().filter(call => call.returnValue === grid._spinnerHiddenTimeout)[0];
+        return call.args;
+      }
+
+      it('should set _spinnerHiddenTimeout when assigning remoteDataProvider', () => {
+        grid.remoteDataProvider = (params, callback) => {};
+        expect(grid._spinnerHiddenTimeout).to.be.ok;
+      });
+
+      it('should hide spinner unless 500ms have passed', () => {
+        grid.remoteDataProvider = (params, callback) => {};
+        expect(grid.shadowRoot.querySelector('px-spinner').hasAttribute('hidden')).to.be.true;
+      });
+
+      it('should have proper timeout', () => {
+        grid.loadingSpinnerDebounce = 1000;
+        const timeout = createTimeoutSpy()[1];
+
+        expect(timeout).to.equal(1000);
+        timeoutSpy.restore();
+      });
+
+      it('should show spinner after 500ms when data is loading', () => {
+        const timeoutCallback = createTimeoutSpy()[0];
+
+        timeoutCallback();
+        expect(grid.shadowRoot.querySelector('px-spinner').hasAttribute('hidden')).to.be.false;
+        timeoutSpy.restore();
+      });
+    });
+
+    describe('selection', () => {
+      beforeEach((done) => {
+        flushVaadinGrid();
+        window.flush(done);
+      });
+
+      it('should add the item to selectedItems when row is clicked', (done) => {
+        grid.selectable = true;
+        grid.multiSelect = true;
+        Polymer.RenderStatus.afterNextRender(grid, () => {
+          expect(grid.selectedItems).to.eql([]);
+          const rows = getRows();
+          let cell = getRowCells(rows[1])[0];
+          cell.click();
+          Polymer.RenderStatus.afterNextRender(grid, () => {
+            expect(grid.selectedItems).to.eql([data[1]]);
+            cell = getRowCells(rows[2])[0];
+            cell.click();
+            Polymer.RenderStatus.afterNextRender(grid, () => {
+              expect(grid.selectedItems).to.eql([data[1], data[2]]);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('single selection', () => {
+      beforeEach((done) => {
+        flushVaadinGrid();
+        window.flush(done);
+      });
+
+      it('should only have one item in selectedItems when rows have been clicked', (done) => {
+        expect(grid.selectedItems).to.eql([]);
+        grid.selectable = true;
+        grid.multiSelect = false;
+        Polymer.RenderStatus.afterNextRender(grid, () => {
+          const rows = getRows();
+          let cell = getRowCells(rows[1])[1];
+          cell.click();
+          Polymer.RenderStatus.afterNextRender(grid, () => {
+            expect(grid.selectedItems).to.eql([data[1]]);
+            cell = getRowCells(rows[2])[1];
+            cell.click();
+            Polymer.RenderStatus.afterNextRender(grid, () => {
+              expect(grid.selectedItems).to.eql([data[2]]);
+              done();
+            });
+          });
+        });
+      });
+    });
+
+    describe('highlighting', () => {
+      beforeEach((done) => {
+        flushVaadinGrid();
+        window.flush(done);
+      });
+
+      it('should highlight cell', () => {
+        grid.highlight = [{
+          type: 'cell',
+          color: 'red',
+          condition: (cellData, column, item) => {
+            return cellData === 'Alma';
+          }
+        }];
+
+        expect(grid._getCellStyle(data[2], grid.columns[0])).to.eql('background: red');
+      });
+
+      it('should highlight row', () => {
+        grid.highlight = [{
+          type: 'row',
+          color: 'yellow',
+          condition: (cellData, item) => {
+            return cellData === 'Saunders';
+          }
+        }];
+
+        expect(grid._getCellStyle(data[3], grid.columns[0])).to.eq('background: yellow');
+        expect(grid._getCellStyle(data[3], grid.columns[1])).to.eq('background: yellow');
+        expect(grid._getCellStyle(data[3], grid.columns[2])).to.eq('background: yellow');
+      });
+
+      it('should highlight column', () => {
+        grid.highlight = [{
+          type: 'column',
+          color: 'blue',
+          condition: (column, item) => {
+            return column.name === 'first';
+          }
+        }];
+
+        data.forEach((d) => {
+          expect(grid._getCellStyle(d, grid.columns[0])).to.eq('background: blue');
+        });
+      });
+    });
+
+    describe('manually passed columns', () => {
+      const columns = [
+        {
+          name: 'first',
+          header: 'First Name',
+          value: (item) => {
+            return item.first;
+          }
+        },
+        {
+          name: 'last',
+          header: 'Last Name',
+          value: (item) => {
+            return item.last;
+          }
+        },
+        {
+          name: 'email',
+          header: 'Email',
+          value: (item) => {
+            return item.email;
+          }
+        },
+        {
+          header: 'Hidden column',
+          hidden: true,
+          value: (item) => {
+            return 'hidden data';
+          }
+        }
+      ];
+
+      it('should change generated column to manually passed', () => {
+        grid.columns = columns;
+        flushVaadinGrid();
+        expect(grid._vaadinGrid.querySelectorAll('px-data-grid-column').length).to.be.eq(4);
+      });
+    });
+
+    describe('column dropdown menu', () => {
+      let firstNameHeaderCell;
+      let lastNameHeaderCell;
+
+      beforeEach(() => {
+        firstNameHeaderCell = getHeaderCell(grid, 0);
+        lastNameHeaderCell = getHeaderCell(grid, 1);
+      });
+
+      it('should move the first frozen column to the left side of the grid', () => {
+        getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
+        expect(getHeaderCell(grid, 0)).to.equal(lastNameHeaderCell);
+        expect(getHeaderCell(grid, 1)).to.equal(firstNameHeaderCell);
+      });
+
+      it('should move the second frozen column to the left side of the grid, before the first frozen', () => {
+        getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
+        getHeaderCellContent(firstNameHeaderCell)._freezeColumn();
+        expect(getHeaderCell(grid, 0)).to.equal(firstNameHeaderCell);
+        expect(getHeaderCell(grid, 1)).to.equal(lastNameHeaderCell);
+      });
+
+      // TODO: @limonte investigate why 2 tests below don't work
+      // it('should move the first unfrozen column right after last frozen', () => {
+      //   getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
+      //   getHeaderCellContent(firstNameHeaderCell)._freezeColumn();
+      //   getHeaderCellContent(firstNameHeaderCell)._unfreezeColumn();
+      //   expect(getHeaderCell(grid, 0)).to.equal(lastNameHeaderCell);
+      //   expect(getHeaderCell(grid, 1)).to.equal(firstNameHeaderCell);
+      // });
+
+      // it('should not change columns order after unfrozing the only one frozen column', () => {
+      //   getHeaderCellContent(lastNameHeaderCell)._freezeColumn();
+      //   getHeaderCellContent(firstNameHeaderCell)._freezeColumn();
+      //   getHeaderCellContent(firstNameHeaderCell)._unfreezeColumn();
+      //   getHeaderCellContent(lastNameHeaderCell)._unfreezeColumn();
+      //   expect(getHeaderCell(grid, 0)).to.equal(lastNameHeaderCell);
+      //   expect(getHeaderCell(grid, 1)).to.equal(firstNameHeaderCell);
+      // });
+
+      it('should hide the column', () => {
+        getHeaderCellContent(firstNameHeaderCell)._hideColumn();
+        expect(firstNameHeaderCell.hasAttribute('hidden')).to.be.true;
+      });
+    });
+
+    describe('local data source', () => {
+
+      beforeEach((done) => {
+        grid = fixture('simple-grid');
+        grid.tableData = data;
+
+        Polymer.RenderStatus.afterNextRender(grid, () => {
+          setTimeout(() => { // IE11
+            done();
+          });
+        });
+      });
+
+      it('cell values in DOM should match that of the local data source', () => {
+        getRows().forEach((row, rowIndex) => {
+          getRowCells(row).forEach((cell, cellIndex) => {
+            // compare value we find in DOM and value in our data object
+            const dataRow = data[rowIndex];
+            const expectedVal = dataRow[Object.keys(dataRow)[cellIndex]];
+            const domVal = getCellContent(cell);
+            expect(domVal).to.be.eql(expectedVal);
+          });
+        });
+      });
+
+    });
+
+    describe('auto filter field tests', () => {
+
+      beforeEach((done) => {
+        grid = fixture('simple-grid');
+        grid.tableData = data;
+        grid.autoFilter = true;
+
+        Polymer.RenderStatus.afterNextRender(grid, () => {
+          setTimeout(() => { // IE11
+            done();
+          });
+        });
+      });
+
+      it('should show only 1 row after filtering', (done) => {
+        const autoFilter = grid.shadowRoot.querySelector('px-auto-filter-field');
+        autoFilter.addEventListener('filter-change', function(event) {
+          expect(getVisibleRows().length).to.be.eql(1);
+          done();
+        });
+        autoFilter.value = 'Elizabeth';
+      });
+
+      it('should show 2 rows after filtering', (done) => {
+        const autoFilter = grid.shadowRoot.querySelector('px-auto-filter-field');
+        autoFilter.addEventListener('filter-change', function(event) {
+          expect(getVisibleRows().length).to.be.eql(2);
+          done();
+        });
+        autoFilter.value = 'am';
+      });
+
+      it('should show all rows when filter value is empty', (done) => {
+        const autoFilter = grid.shadowRoot.querySelector('px-auto-filter-field');
+        // set filter with value to reduce # of visible rows
+        autoFilter.value = 'am';
+        // give 500ms to let rows update
+        setTimeout(function() {
+          // add listener and clear filter value to let all rows become visible
+          autoFilter.addEventListener('filter-change', function(event) {
+            expect(getVisibleRows().length).to.be.eql(data.length);
+            done();
+          });
+          autoFilter.value = '';
+        }, autoFilter.timeout + 100);
+      });
+
+    });
+
+  });
+}


### PR DESCRIPTION
Still in WiP, but:
- This will fix select/deselect behavior without items
- And disables select all for remote data source totally (as it might be really expensive)

Still to do:
- Actual single selection mode