### PR TITLE
Navigation component fixes, tests, and pagination data provider logic

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -7,6 +7,7 @@
 <link rel="import" href="px-data-grid-column-demo.html">
 <link rel="import" href="px-data-grid-highlight-demo.html">
 <link rel="import" href="px-data-grid-remote-data-provider-demo.html">
+<link rel="import" href="px-data-grid-paginated-demo.html">
 
 <!-- Demo DOM module -->
 <dom-module id="local-element-demo">
@@ -48,6 +49,10 @@
                   name: 'Remote data provider',
                   tagName: 'px-data-grid-remote-data-provider-demo'
                 },
+                {
+                  name: 'Pagination examples',
+                  tagName: 'px-data-grid-paginated-demo'
+                }
               ];
             }
           },

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -1,0 +1,529 @@
+<!-- Common demo imports -->
+<link rel="import" href="../../px-demo/px-demo-header.html" />
+<link rel="import" href="../../px-demo/px-demo-api-viewer.html" />
+<link rel="import" href="../../px-demo/px-demo-footer.html" />
+<link rel="import" href="../../px-demo/px-demo-configs.html" />
+<link rel="import" href="../../px-demo/px-demo-props.html" />
+<link rel="import" href="../../px-demo/px-demo-interactive.html" />
+<link rel="import" href="../../px-demo/px-demo-component-snippet.html" />
+<link rel="import" href="../../px-demo/px-demo-code-editor.html" />
+
+<!-- Imports for this component -->
+<link rel="import" href="../css/px-demo-styles.html" />
+<link rel="import" href="../px-data-grid-paginated.html" />
+
+<!-- Demo DOM module -->
+<dom-module id="px-data-grid-paginated-demo">
+  <template>
+    <style>
+      .theme-switcher-checkbox {
+        display: inline-flex;
+        float: right;
+        margin: 1rem 2rem;
+      }
+
+      .theme-switcher-checkbox input {
+        margin-left: 5px;
+      }
+    </style>
+    <custom-style>
+      <style include="px-demo-styles" is="custom-style"></style>
+    </custom-style>
+
+    <!-- Header -->
+    <px-demo-header
+        module-name="px-data-grid"
+        description="The Data Grid component is useful for displaying tabular data, and provides more functionality than a simple table."
+        mobile desktop tablet>
+    </px-demo-header>
+
+    <!-- Interactive -->
+    <px-demo-interactive>
+      <!-- Configs -->
+      <px-demo-configs slot="px-demo-configs" configs="[[configs]]" props="{{props}}" chosen-config="{{chosenConfig}}"></px-demo-configs>
+
+      <!-- Props -->
+      <px-demo-props slot="px-demo-props" props="{{props}}" config="[[chosenConfig]]"></px-demo-props>
+
+      <!-- Code Editor -->
+      <px-demo-code-editor slot="px-demo-code-editor" props="{{props}}" config="[[chosenConfig]]"></px-demo-code-editor>
+
+      <!-- Component ---------------------------------------------------------->
+      <px-demo-component slot="px-demo-component">
+        <px-data-grid-paginated
+            table-data="{{props.tableData.value}}"
+            selectable="{{props.selectable.value}}"
+            multi-select="{{props.multiSelect.value}}"
+            selected-items="{{selectedItems}}"
+            hide-selection-column="{{props.hideSelectionColumn.value}}"
+            resizable="{{props.resizable.value}}"
+            striped="{{props.striped.value}}"
+            multi-sort="{{props.multiSort.value}}"
+            column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
+            action-menu="{{props.actionMenu.value}}"
+            language="{{props.language.value}}"
+            auto-filter="{{props.autoFilter.value}}"
+            on-cell-hover="cellHoverListener"
+            on-cell-unhover="cellUnhoverListener">
+        </px-data-grid-paginated>
+
+        <dom-if if="[[selectedItems.length]]">
+          <template>
+            Selected items:
+            <ul>
+              <template is="dom-repeat" items="{{selectedItems}}">
+                <li>[[_stringify(item)]]</li>
+              </template>
+            </ul>
+          </template>
+        </dom-if>
+
+        <label>
+          <input type="checkbox" checked="{{showHoveredCellData::change}}">
+          Show hovered cell data
+        </label>
+        <template is="dom-if" if="[[showHoveredCellData]]"><div>Hovered cell data: [[hoveredCellData]]</div></template>
+      </px-demo-component>
+      <!-- END Component ------------------------------------------------------>
+
+      <px-demo-component-snippet
+          slot="px-demo-component-snippet"
+          element-properties="{{props}}"
+          element-name="px-data-grid"
+          links-includes="[[linksIncludes]]">
+      </px-demo-component-snippet>
+    </px-demo-interactive>
+
+    <!-- API Viewer -->
+    <px-demo-api-viewer source="px-data-grid" api-source-file-path="px-data-grid-api.json"></px-demo-api-viewer>
+
+    <!-- Footer -->
+    <px-demo-footer></px-demo-footer>
+
+  </template>
+
+</dom-module>
+<script>
+  Polymer({
+    is: 'px-data-grid-paginated-demo',
+
+    cellHoverListener: function(evt) {
+      this.hoveredCellData = evt.detail.cellContent;
+    },
+
+    cellUnhoverListener: function(evt) {
+      if (this.hoveredCellData === evt.detail.cellContent) {
+        this.hoveredCellData = '';
+      }
+    },
+
+    properties: {
+      showHoveredCellData: {
+        type: Boolean,
+        value: false,
+      },
+
+      hoveredCellData: {
+        type: String
+      },
+      /**
+       * Note: The actual data/values for `props` are placed in `this.demoProps`
+       * to create a static reference that Polymer shouldn't overwrite.
+       *
+       * On object containing all the properties the user can configure for this
+       * demo. Usually a pretty similar copy of the component's `properties` block
+       * with some additional sugar added to describe what kind of input the
+       * user will be shown and how that input should be configured.
+       *
+       * Note that `value` for each property is the default that will be set
+       * unless a config from `configs` is applied by default.
+       *
+       * @property props
+       * @type {Object}
+       */
+      props: {
+        type: Object,
+        value: function() {
+          return this.demoProps;
+        }
+      },
+
+      /**
+       * An array of pre-configured `props` that can be used to provide the user
+       * with a set of common examples. These configs will be made available
+       * as a set of tabs the user can click that will automatically change
+       * the `props` to specific values.
+       *
+       * @example
+       *
+       * Each config is an object. Its keys should be the names of the configurable
+       * properties defined in your `demoProps` above. Each key's value should
+       * be the new prop value for the configuration. You can also include these
+       * optional keys:
+       *
+       * - `configName` - a String value that will be used for the title of the tab
+       * - `configReset` - a Boolean, if `true` resets all props. Defaults to `false`.
+       *
+       * @property configs
+       * @type {Array}
+       */
+      configs: {
+        type: Array,
+        value: function() {
+          return [
+            {
+              configName: 'Default',
+              configReset: true
+            },
+            {
+              configName: 'More rows (scrollable)',
+              configReset: true,
+              tableData: [
+                {
+                  first: 'Elizabeth',
+                  last: 'Wong',
+                  email: 'sika@iknulber.cl'
+                },
+                {
+                  first: 'Jeffrey',
+                  last: 'Hamilton',
+                  email: 'cofok@rac.be'
+                },
+                {
+                  first: 'Alma',
+                  last: 'Martin',
+                  email: 'dotta@behtam.la'
+                },
+                {
+                  first: 'Carl',
+                  last: 'Saunders',
+                  email: 'seh@bibapu.gy'
+                },
+                {
+                  first: 'Willie',
+                  last: 'Dennis',
+                  email: 'izko@dahokwej.ci'
+                },
+                {
+                  first: 'Angel',
+                  last: 'Lewis',
+                  email: 'ma@et.nz'
+                },
+                {
+                  first: 'Jessie',
+                  last: 'Sherman',
+                  email: 'hunocnas@mosuraj.gi'
+                },
+                {
+                  first: 'Eric',
+                  last: 'Brewer',
+                  email: 'tu@coajoul.de'
+                },
+                {
+                  first: 'Cory',
+                  last: 'Ramos',
+                  email: 'kilamja@oviafbek.ss'
+                },
+                {
+                  first: 'Bertie',
+                  last: 'Ross',
+                  email: 'ifuvu@getvi.my'
+                },
+                {
+                  first: 'Oscar',
+                  last: 'Estrada',
+                  email: 'minu@kerireg.gp'
+                },
+                {
+                  first: 'Estelle',
+                  last: 'Patton',
+                  email: 'hudliami@lijihen.fi'
+                },
+                {
+                  first: 'Sallie',
+                  last: 'George',
+                  email: 'wo@zof.bf'
+                },
+                {
+                  first: 'Harriett',
+                  last: 'Wheeler',
+                  email: 'woguw@cibevo.pt'
+                },
+                {
+                  first: 'Bryan',
+                  last: 'Houston',
+                  email: 'tekkubom@gaahu.ge'
+                },
+                {
+                  first: 'Leon',
+                  last: 'Craig',
+                  email: 'wo@gurozo.gs'
+                },
+                {
+                  first: 'Mable',
+                  last: 'Taylor',
+                  email: 'um@fegnocka.pg'
+                },
+                {
+                  first: 'Ida',
+                  last: 'Hansen',
+                  email: 'lufahu@gewlaskoc.kh'
+                },
+                {
+                  first: 'Adele',
+                  last: 'Thornton',
+                  email: 'gugugo@nevigi.th'
+                },
+                {
+                  first: 'Jerry',
+                  last: 'Kelley',
+                  email: 'solef@zoose.as'
+                },
+                {
+                  first: 'Clara',
+                  last: 'Delgado',
+                  email: 'fivticnuf@upkib.rw'
+                },
+                {
+                  first: 'Joseph',
+                  last: 'Stevenson',
+                  email: 'be@viijo.lk'
+                },
+                {
+                  first: 'Ellen',
+                  last: 'Perry',
+                  email: 'ce@jewo.sv'
+                },
+                {
+                  first: 'Ronnie',
+                  last: 'Cummings',
+                  email: 'iro@wi.vn'
+                },
+                {
+                  first: 'Olive',
+                  last: 'Santos',
+                  email: 'vo@nees.cn'
+                },
+                {
+                  first: 'Rena',
+                  last: 'Tucker',
+                  email: 'uharoc@lohpol.gl'
+                },
+                {
+                  first: 'Nell',
+                  last: 'Hicks',
+                  email: 'felaf@vo.sb'
+                },
+                {
+                  first: 'Jesus',
+                  last: 'Hawkins',
+                  email: 'wahgab@mu.mk'
+                },
+                {
+                  first: 'Duane',
+                  last: 'Harris',
+                  email: 'kellanjob@daava.ph'
+                },
+                {
+                  first: 'Jonathan',
+                  last: 'Holmes',
+                  email: 'jir@bikuf.dj'
+                },
+                {
+                  first: 'Christine',
+                  last: 'Collier',
+                  email: 'bocago@jerla.ba'
+                },
+                {
+                  first: 'Brandon',
+                  last: 'Thompson',
+                  email: 'regoh@ji.kn'
+                },
+                {
+                  first: 'Anne',
+                  last: 'Dunn',
+                  email: 'samhof@are.sc'
+                },
+                {
+                  first: 'Viola',
+                  last: 'Sherman',
+                  email: 'wep@kezori.lt'
+                },
+                {
+                  first: 'Kathryn',
+                  last: 'Harper',
+                  email: 'keotoci@je.mr'
+                },
+                {
+                  first: 'Calvin',
+                  last: 'Bates',
+                  email: 'bomeg@lip.bw'
+                },
+                {
+                  first: 'Maggie',
+                  last: 'Collins',
+                  email: 'zonefto@ihihij.ke'
+                },
+                {
+                  first: 'Zachary',
+                  last: 'Mitchell',
+                  email: 'wamez@cilvahbod.mk'
+                },
+                {
+                  first: 'Raymond',
+                  last: 'Kelley',
+                  email: 'wuz@napujos.tt'
+                },
+                {
+                  first: 'Augusta',
+                  last: 'Torres',
+                  email: 'bum@ne.lt'
+                },
+                {
+                  first: 'Charlie',
+                  last: 'Lindsey',
+                  email: 'ruhlu@tuobujen.ao'
+                },
+                {
+                  first: 'Jeremy',
+                  last: 'Swanson',
+                  email: 'ed@ted.km'
+                },
+                {
+                  first: 'Joel',
+                  last: 'Gonzalez',
+                  email: 'ej@pot.bz'
+                },
+                {
+                  first: 'Lillie',
+                  last: 'Hawkins',
+                  email: 'uguiv@mudbuve.pa'
+                },
+                {
+                  first: 'Joel',
+                  last: 'Watts',
+                  email: 'naafe@oli.bb'
+                },
+                {
+                  first: 'Isabella',
+                  last: 'Sandoval',
+                  email: 'asobu@wedef.af'
+                },
+                {
+                  first: 'Roy',
+                  last: 'Lyons',
+                  email: 'rasaogu@tadiri.tc'
+                }
+              ]
+            }
+          ];
+        }
+      },
+
+      selectedItems: {
+        type: Array,
+      }
+    },
+    /**
+     * A reference for `this.props`. Read the documentation there.
+     */
+    demoProps: {
+      tableData: {
+        type: Object,
+        defaultValue: [
+          {
+            first: 'Elizabeth',
+            last: 'Wong',
+            email: 'sika@iknulber.cl'
+          },
+          {
+            first: 'Jeffrey',
+            last: 'Hamilton',
+            email: 'cofok@rac.be'
+          },
+          {
+            first: 'Alma',
+            last: 'Martin',
+            email: 'dotta@behtam.la'
+          },
+          {
+            first: 'Carl',
+            last: 'Saunders',
+            email: 'seh@bibapu.gy'
+          },
+          {
+            first: 'Willie',
+            last: 'Dennis',
+            email: 'izko@dahokwej.ci'
+          }
+        ],
+        inputType: 'code:JSON'
+      },
+
+      selectable: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      multiSelect: {
+        type: Boolean,
+        defaultValue: true,
+        inputType: 'toggle'
+      },
+
+      hideSelectionColumn: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      multiSort: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      columnReorderingAllowed: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      actionMenu: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      autoFilter: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      resizable: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      striped: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      language: {
+        type: String,
+        value: 'en',
+        inputType: 'dropdown',
+        inputChoices: ['en', 'fr', 'fi']
+      }
+    },
+
+    _stringify: function(item) {
+      return JSON.stringify(item);
+    }
+  });
+</script>

--- a/px-data-grid-navigation.html
+++ b/px-data-grid-navigation.html
@@ -18,6 +18,7 @@
       .right {
         display: inline-block;
         position: absolute;
+        top: 4px; /* this is to vertically align with px-dropdown's height */
         right: 0;
         padding-right: var(--px-data-grid-padding-right, 12px);
       }
@@ -52,23 +53,32 @@
         cursor: pointer;
       }
 
-      .page-selection .arrow.disabled {
+      .page-selection .arrow:disabled {
         color: var(--px-data-grid-navigation-text-color--disabled, #CCC);
         cursor: default;
+      }
+
+      .page-selection .arrow:focus {
+        outline: none;
       }
 
       .page-selection .page-list {
         display: inline-block;
       }
 
-      .page-selection .page-list .page-button {
+      .page-selection .page-button {
+        color: var(--px-data-grid-navigation-text-color, #000);
         display: inline-block;
         cursor: pointer;
-        padding: 5px 7px;
+        padding: 2px 7px;
+        background: none;
+        margin: 0;
+        border: none;
       }
 
       .page-selection .page-list .page-button.selected {
         border: solid 1px var(--px-data-grid-navigation-page-number-border-color, #CCC);
+        border-radius: 0;
         color: var(--px-data-grid-navigation-text-color--selected, #000);
       }
     </style>
@@ -87,48 +97,38 @@
     <div class="right">
       <!-- row counts -->
       <div class="row-counts">
-        <span class="current-rows">[[_getItemsRangeStr()]]</span> of [[totalItemCount]]
+        <span class="current-rows">
+          [[_getItemsRangeStr(currentPage, pageSize, totalItemCount)]]
+        </span> of [[totalItemCount]]
       </div>
 
       <!-- page selection list -->
       <div class="page-selection">
         <!-- back arrow -->
-        <template is="dom-if" if="[[_isCurrentPage(1)]]">
-          <div class="arrow disabled">
-            <px-icon icon="px-nav:back"></px-icon>
-          </div>
-        </template>
-        <template is="dom-if" if="[[!_isCurrentPage(1)]]">
-          <div class="arrow" on-tap="_onBackTap">
-            <px-icon icon="px-nav:back"></px-icon>
-          </div>
-        </template>
+        <button class="page-button arrow" on-tap="_onBackTap"
+            disabled$="[[!_isBackArrowEnabled(currentPage, numberOfPages)]]">
+          <px-icon icon="px-nav:back"></px-icon>
+        </button>
         <!-- page number list -->
         <div class="page-list">
-          <template is="dom-repeat" items="[[_getPagesList()]]">
-            <template is="dom-if" if="[[_isCurrentPage(item)]]">
-              <div class="page-button selected" on-tap="_onPageTap">
+          <template is="dom-repeat" items="[[_getPagesList(currentPage, numberOfPages)]]">
+            <template is="dom-if" if="[[_isCurrentPage(item, currentPage)]]" restamp>
+              <div class="page-button page-number selected">
                 [[item]]
               </div>
             </template>
-            <template is="dom-if" if="[[!_isCurrentPage(item)]]">
-              <div class="page-button" on-tap="_onPageTap">
+            <template is="dom-if" if="[[!_isCurrentPage(item, currentPage)]]" restamp>
+              <div class="page-button page-number" on-tap="_onPageTap">
                 [[item]]
               </div>
             </template>
           </template>
         </div>
         <!-- next arrow -->
-        <template is="dom-if" if="[[_isCurrentPage(numberOfPages)]]">
-          <div class="arrow disabled">
-            <px-icon icon="px-nav:next"></px-icon>
-          </div>
-        </template>
-        <template is="dom-if" if="[[!_isCurrentPage(numberOfPages)]]">
-          <div class="arrow" on-tap="_onNextTap">
-            <px-icon icon="px-nav:next"></px-icon>
-          </div>
-        </template>
+        <button class="page-button arrow" on-tap="_onNextTap"
+            disabled$="[[!_isNextArrowEnabled(currentPage, numberOfPages)]]">
+          <px-icon icon="px-nav:next"></px-icon>
+        </button>
       </div>
     </div>
 
@@ -242,13 +242,18 @@
          */
         _onPageTap(event) {
           const pageNumber = Number.parseInt(event.path[0].innerText);
-          this._fireChangeEvent({
-            pageSize: this.pageSize,
-            currentPage: pageNumber
-          });
+          if (!isNaN(pageNumber)) {
+            this._fireChangeEvent({
+              pageSize: this.pageSize,
+              currentPage: pageNumber
+            });
+          }
         }
 
         _onBackTap(event) {
+          if (this.currentPage == 1) {
+            return;
+          }
           this._fireChangeEvent({
             pageSize: this.pageSize,
             currentPage: this.currentPage - 1
@@ -256,6 +261,9 @@
         }
 
         _onNextTap(event) {
+          if (this.currentPage == this.numberOfPages) {
+            return;
+          }
           this._fireChangeEvent({
             pageSize: this.pageSize,
             currentPage: this.currentPage + 1
@@ -293,11 +301,13 @@
          * Returns string showing the min and max item numbers based on
          * the current page.
          */
-        _getItemsRangeStr() {
-          const min = this.currentPage * this.pageSize;
-          let max = (this.currentPage + 1) * this.pageSize;
-          // dont let max be greater than total item count
-          max = (this.totalItemCount > 0 && max > this.totalItemCount) ? this.totalItemCount : max;
+        _getItemsRangeStr(currentPage, pageSize, totalItemCount) {
+          // min can be no less than 1
+          let min = (currentPage - 1) * pageSize + 1;
+          min = (min < 1) ? 1 : min;
+          // max can be no more than totalItemCount
+          let max = currentPage * pageSize;
+          max = (totalItemCount > 0 && max > totalItemCount) ? totalItemCount : max;
           return min + ' - ' + max;
         }
 
@@ -305,7 +315,6 @@
          * Gets an array of page numbers based on the numberOfPages property.
          */
         _getPagesList() {
-
           // TODO: change ellipsis to use &hellip;
 
           const pageList = [];
@@ -354,6 +363,14 @@
          */
         _isCurrentPage(pageNumber) {
           return this.currentPage === pageNumber;
+        }
+
+        _isBackArrowEnabled(currentPage) {
+          return currentPage > 1;
+        }
+
+        _isNextArrowEnabled(currentPage) {
+          return currentPage < this.numberOfPages;
         }
 
       }

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -1,0 +1,540 @@
+<link rel="import" href="../polymer/polymer-element.html">
+<link rel="import" href="../vaadin-grid/vaadin-grid.html">
+<link rel="import" href="../vaadin-grid/vaadin-grid-selection-column.html">
+<link rel="import" href="../vaadin-grid/vaadin-grid-sorter.html">
+<link rel="import" href="../px-spinner/px-spinner.html">
+<link rel="import" href="px-data-grid-column.html">
+<link rel="import" href="px-auto-filter-field.html">
+<link rel="import" href="px-data-grid-navigation.html">
+<link rel="import" href="px-data-grid-theme.html">
+<link rel="import" href="px-data-grid-selection-column.html">
+<link rel="import" href="../app-localize-behavior/app-localize-behavior.html"/>
+
+<link rel="import" href="px-data-grid-string-renderer.html">
+<link rel="import" href="px-data-grid-cell-content-wrapper.html">
+
+<dom-module id="px-data-grid-paginated">
+  <template>
+    <style>
+      :host {
+        position: relative;
+        display: block;
+      }
+
+      px-data-grid-navigation {
+        width: 100%;
+      }
+    </style>
+
+    <px-data-grid
+      remote-data-provider="{{_currentDataProvider}}"
+      selectable="{{selectable}}"
+      multi-select="{{multiSelect}}"
+      selected-items="{{selectedItems}}"
+      hide-selection-column="{{hideSelectionColumn}}"
+      resizable="{{resizable}}"
+      striped="{{striped}}"
+      multi-sort="{{multiSort}}"
+      column-reordering-allowed="{{columnReorderingAllowed}}"
+      action-menu="{{actionMenu}}"
+      language="{{language}}"
+      auto-filter="{{autoFilter}}">
+    </px-data-grid>
+
+    <px-data-grid-navigation
+      total-item-count="[[size]]"
+      on-navigation-change="_onNavigationChange"
+      selectable-page-sizes="[[selectablePageSizes]]"
+      page-size="[[pageSize]]"
+      current-page="[[page]]"
+      number-of-pages="[[_calcNumPages(size, pageSize)]]">
+    </px-data-grid-navigation>
+
+  </template>
+  <script>
+    {
+      class DataGridPaginatedElement extends Polymer.Element {
+
+        static get is() {
+          return 'px-data-grid-paginated';
+        }
+
+        static get properties() {
+          return {
+
+            /**
+             * Data for the table to display.
+             *
+             * Expected data format is a JSON array of objects. Each object in the array represents a row in the table.
+             *
+             * Each item in an object will be displayed as a separate column, unless px-data-table-columns are
+             * defined to limit which columns are displayed.
+             */
+            tableData: {
+              type: Array,
+              observer: '_tableDataChanged',
+              notify: true
+            },
+
+            /**
+             * Use the selectable property if one or more rows within the table should be selectable. See also `singleSelect`.
+             */
+            selectable: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * If true, hides the column with checkboxes.
+             */
+            hideSelectionColumn: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * An array that contains the selected items.
+             */
+            selectedItems: {
+              type: Array,
+              value: () => [],
+              notify: true
+            },
+
+            /**
+             * The total number of items
+             */
+            size: {
+              type: Number,
+              value: undefined,
+              observer: '_ensureValidPageNumber'
+            },
+
+            /**
+             * Number of items fetched at a time from the dataprovider.
+             */
+            pageSize: {
+              type: Number,
+              value: 10,
+              observer: '_onPageSizeChange'
+            },
+
+            selectablePageSizes: {
+              type: Array,
+              value: [10, 20, 30]
+            },
+
+            /**
+             * Current page number of displayed items. Page 1 should be the minimum value.
+             */
+            page: {
+              type: Number,
+              value: 1,
+              observer: '_onPageChange'
+            },
+
+            /**
+             * When `true`, user can sort by multiple columns
+             */
+            multiSort: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * When `true`, selection mode will be multiselection when selectable
+             */
+            multiSelect: {
+              type: Boolean,
+              value: true
+            },
+
+            /**
+             * The item user has last interacted with. Turns to `null` after user deactivates
+             * the item by re-interacting with the currently active item.
+             */
+            activeItem: {
+              type: Object,
+              notify: true,
+              value: null
+            },
+
+            /**
+             * When `true`, user can resize columns
+             */
+            resizable: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * Set to true to allow column reordering.
+             */
+            columnReorderingAllowed: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+            * An array containing references to expanded items.
+            */
+            expandedItems: {
+              type: Array,
+              value: []
+            },
+
+            /**
+             * Define if table action menu is shown or not
+             */
+            actionMenu: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * Grid columns. If no columns are passed, grid generates columns from passed data.
+             * Format:
+             * ```javascript
+             * {
+             *   name: 'first',
+             *   hidden: false,
+             *   header: 'First name',
+             *   value: (item) => {
+             *     return item.first;
+             *   }
+             * },
+             * ```
+             * In case px-data-table-columns aren't provided, table columns will be generated automatically.
+             * They will be stamped via
+             *
+             * <template is="dom-repeat" items="[[_generatedColumns]]">
+             *   ...
+             * </template>
+             *
+             * @private
+             */
+            columns: {
+              type: Array,
+              value: []
+            },
+
+            /**
+             * A valid IETF language tag as a string that `app-localize-behavior` will
+             * use to localize this component.
+             *
+             * See https://github.com/PolymerElements/app-localize-behavior for API
+             * documentation and more information.
+             */
+            language: {
+              type: String,
+              value: 'en'
+            },
+
+            /**
+             * Use the key for localization if value for that language is missing.
+             * Should always be true for Predix components.
+             */
+            useKeyIfMissing: {
+              type: Boolean,
+              value: true
+            },
+
+            /**
+             * Library object of hardcoded strings used in this application.
+             * Used by `app-localize-behavior` in conjunction with `language`.
+             */
+            resources: {
+              type: Object,
+              value: () => {
+                // can also load these from external file as shown here:
+                // https://www.polymer-project.org/2.0/toolbox/localize
+                return {
+                  'en': {
+                    'Table Actions': 'Table Actions',
+                    'Freeze column': 'Freeze column',
+                    'Unfreeze column': 'Unfreeze column',
+                    'Hide column': 'Hide column'
+                  },
+                  'fr': {
+                    'Table Actions': 'Actions de la table'
+                  },
+                  'fi': {
+                    'Table Actions': 'Taulukkotoiminnot',
+                    'Hide column': 'Piilota sarake'
+                  }
+                };
+              }
+            },
+
+            /**
+             * All custom table actions. Should return array of objects with 'name' (String) and 'action' (function).
+             */
+            tableActions: {
+              type: Array,
+              value: []
+            },
+
+            /**
+             * Function that provides items lazily. Receives arguments params, callback
+             */
+            remoteDataProvider: {
+              type: Function,
+              observer: '_remoteDataProviderChanged'
+            },
+
+            _currentDataProvider: {
+              type: Function
+            },
+
+            /**
+             * If true, every other row in the table will appear with a background color to improve visual scanning.
+             */
+            striped: {
+              type: Boolean,
+              value: false
+            },
+
+
+            /**
+             * How many milliseconds before loading spinner will be shown
+             */
+            loadingSpinnerDebounce: {
+              type: Number,
+              value: 500
+            },
+
+            /**
+             * To enable automatic filtering change property to true
+             */
+            autoFilter: {
+              type: Boolean,
+              value: false
+            },
+
+            /**
+             * Array of objects of conditions used to highlight specific columns.
+             * Format:
+             * ```javascript
+             * {
+             *   type: 'cell',
+             *   condition: (cellContent, column, item) => { return cellContent == 'John Doe' },
+             * },
+             * {
+             *   type: 'row',
+             *   condition: (cellContent, item) => { return cellContent[0] == 'a' },
+             *   color: '#a8a8a8'
+             * },
+             * {
+             *   type: 'column',
+             *   condition (column, item) => { return column.name == 'age' },
+             *   color: 'pink'
+             * }
+             * ```
+             */
+            highlight: {
+              type: Array,
+              value: []
+            },
+
+            /**
+             * When true data provider is local, when false external (remote) and
+             * when undefined it defined yet.
+             */
+            _hasLocalDataProvider: {
+              type: Boolean
+            },
+
+            /**
+             * Default column width if not defined, eg. '100px'
+             */
+            defaultColumnWidth: {
+              type: String,
+              value: '100px'
+            },
+
+            /**
+             * Default column flex if not defined, eg. 1
+             */
+            defaultColumnFlex: {
+              type: Number,
+              value: 1
+            }
+
+          };
+        }
+
+        ready() {
+          super.ready();
+          this._pxDataGrid = this.shadowRoot.querySelector('px-data-grid');
+        }
+
+        _tableDataChanged(tableData) {
+          if (tableData) {
+            this._hasLocalDataProvider = true;
+            this._currentDataProvider = this._wrapDataProvider(this._localDataProvider);
+          }
+        }
+
+        _remoteDataProviderChanged(provider) {
+          this._hasLocalDataProvider = false;
+          this._currentDataProvider = this._wrapDataProvider(provider);
+        }
+
+        /**
+         * Wrap the supplied data provider in order to manipulate the request and data
+         * to work with our pagination state.
+         */
+        _wrapDataProvider(provider) {
+          // TODO: fix this... doesn't work without assigning to 'this', not sure why
+          this._baseDataProvider = provider;
+
+          const wrappedProvider = function(params, callback) {
+            // override page and page size params with ours
+            params.page = this.page - 1;
+            params.pageSize = this.pageSize;
+            // wrap the callback
+            this._baseDataProvider(params, function(items, size) {
+              // keep a reference to the total number of items (needed for pagination ui)
+              this.size = size;
+              // pass the vaadin grid the page size (or items size if less) so that
+              // vaadin grid only displays this many items at a time (aka a single page of rows)
+              const numDisplayedRows = (items.length > params.pageSize) ? params.pageSize : items.length;
+              callback(items, numDisplayedRows);
+              this._pxDataGrid._populateTableColumns(items);
+            }.bind(this));
+          }.bind(this);
+
+          return wrappedProvider;
+        }
+
+        _localDataProvider(params, callback) {
+          const items = (Array.isArray(this.tableData) ? this.tableData : []).slice(0);
+          const response = this._localDataResolver(params, items);
+          callback(response.items, response.total);
+        }
+
+        _localDataResolver(params, items) {
+          if (params.filters && params.filters.length && this._pxDataGrid._vaadinGrid._checkPaths(params.filters, 'filtering', items)) {
+            items = this._pxDataGrid._filter(items, params.filters);
+          }
+
+          if (params.sortOrders
+            && params.sortOrders.length
+            && this._pxDataGrid._vaadinGrid._checkPaths(this._pxDataGrid._sorters, 'sorting', items)) {
+            const multiSort = (a, b) => {
+              return params.sortOrders.map(sort => {
+                if (sort.direction === 'asc') {
+                  return this._pxDataGrid._vaadinGrid._compare(Polymer.Base.get(sort.path, a), Polymer.Base.get(sort.path, b));
+                } else if (sort.direction === 'desc') {
+                  return this._pxDataGrid._vaadinGrid._compare(Polymer.Base.get(sort.path, b), Polymer.Base.get(sort.path, a));
+                }
+                return 0;
+              }).reduce((p, n) => {
+                return p ? p : n;
+              }, 0);
+            };
+
+            items = items.sort(multiSort);
+          }
+
+          const total = items.length;
+          const start = params.page * params.pageSize;
+          const end = start + params.pageSize;
+
+          return {
+            items: items.slice(start, end),
+            total: total
+          };
+        }
+
+        /**
+         * Will return all local items after filter (no ordering applied)
+         */
+        _getAllLocalItems() {
+          if (this._hasLocalDataProvider) {
+            const items = (Array.isArray(this.tableData) ? this.tableData : []).slice(0);
+            return this._localDataResolver({
+              page: 0,
+              pageSize: this.tableData.length
+            }, items);
+          } else {
+            return [];
+          }
+        }
+
+        /**
+         * Listener for px-data-grid-navigation component
+         */
+        _onNavigationChange(event) {
+          // update page size
+          if (this.pageSize !== event.detail.pageSize) {
+            this.pageSize = event.detail.pageSize;
+          }
+          // update current page number
+          if (this.page !== event.detail.currentPage) {
+            this.page = event.detail.currentPage;
+          }
+        }
+
+        _onPageSizeChange(pageSize) {
+          this._ensureValidPageSize();
+          this._updateGridData();
+        }
+
+        _onPageChange(page) {
+          this._ensureValidPageNumber();
+          this._updateGridData();
+        }
+
+        /**
+         * Update grid data via the current data provider.
+         */
+        _updateGridData() {
+          // clear grid cache to force loading data from data provider
+          if (this._pxDataGrid) {
+            this._pxDataGrid._vaadinGrid.clearCache();
+          }
+        }
+
+        /**
+         * Checks if current page is smaller than the total number of pages
+         * and larger than 0.
+         * If it is not valid, then reset it to 1.
+         */
+        _ensureValidPageNumber() {
+          const numPages = this._calcNumPages(this.size, this.pageSize);
+          // page must be at least 1
+          this.page = (this.page > 0) ? this.page : 1;
+          // page cannot be greater than total number of pages
+          this.page = (numPages < this.page) ? 1 : this.page;
+        }
+
+        /**
+         * Ensure page size is valid (greater than 0). If page size in invalid,
+         * page size will be set to 10.
+         */
+        _ensureValidPageSize() {
+          this.pageSize = (this.pageSize > 0) ? this.pageSize : 10;
+        }
+
+        /**
+         * Calculates the number pages based on  total number of rows and the page size
+         */
+        _calcNumPages(numItems, pageSize) {
+          let numPages = 1;
+          if (pageSize) {
+            numPages = Math.round(numItems / pageSize);
+          }
+          return numPages;
+        }
+      }
+      customElements.define(DataGridPaginatedElement.is, DataGridPaginatedElement);
+
+      /**
+       * @namespace Predix
+       */
+      window.Predix = window.Predix || {};
+      Predix.DataGridPaginatedElement = DataGridPaginatedElement;
+    }
+  </script>
+</dom-module>

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -5,7 +5,6 @@
 <link rel="import" href="../px-spinner/px-spinner.html">
 <link rel="import" href="px-data-grid-column.html">
 <link rel="import" href="px-auto-filter-field.html">
-<link rel="import" href="px-data-grid-navigation.html">
 <link rel="import" href="px-data-grid-theme.html">
 <link rel="import" href="px-data-grid-selection-column.html">
 <link rel="import" href="../app-localize-behavior/app-localize-behavior.html"/>
@@ -177,15 +176,6 @@
 
     </vaadin-grid>
 
-    <!-- pagination component -->
-    <template is="dom-if" if="[[pagination]]">
-      <div class="action-bar">
-        <px-data-grid-navigation
-          on-navigation-change="_onNavigationChange">
-        </px-data-grid-navigation>
-      </div>
-    </template>
-
     <px-spinner size="40" hidden$="[[_spinnerHidden]]"></px-spinner>
   </template>
   <script>
@@ -333,14 +323,6 @@
             columns: {
               type: Array,
               value: []
-            },
-
-            /**
-             * Define if table uses paging to display data
-             */
-            pagination: {
-              type: Boolean,
-              value: false
             },
 
             /**
@@ -1147,13 +1129,6 @@
           this.set('_filterHighlights', filterHighlights);
 
           this._vaadinGrid.clearCache();
-        }
-
-        /**
-         * Listener for px-data-grid-navigation component
-         */
-        _onNavigationChange(event) {
-
         }
       }
       customElements.define(DataGridElement.is, DataGridElement);

--- a/test/px-data-grid-fixture.html
+++ b/test/px-data-grid-fixture.html
@@ -8,6 +8,8 @@
 
     <script src="../bower_components/web-component-tester/browser.js"></script>
     <link rel="import" href="../px-data-grid.html">
+    <link rel="import" href="../px-data-grid-paginated.html">
+    <link rel="import" href="../px-data-grid-navigation.html">
     <link rel="import" href="helpers.html">
   </head>
 
@@ -20,6 +22,26 @@
       </template>
     </test-fixture>
 
+    <test-fixture id="simple-navigation">
+      <template>
+        <px-data-grid-navigation
+          selectable-page-sizes="[10, 20, 30]"
+          page-size="10"
+          total-item-count="300"
+          current-page="1"
+          number-of-pages="50">
+        </px-data-grid-navigation>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="px-data-grid-paginated-fixture">
+      <template>
+        <px-data-grid-paginated>
+        </px-data-grid-paginated>
+      </template>
+    </test-fixture>
+
+
     <script src="generated-columns.js"></script>
     <script src="local-data-provider.js"></script>
     <script src="selection.js"></script>
@@ -28,6 +50,8 @@
     <script src="auto-filter.js"></script>
     <script src="columns-api.js"></script>
     <script src="column-dropdown-menu.js"></script>
+    <script src="px-data-grid-navigation-test.js"></script>
+    <script src="px-data-grid-paginated-test.js"></script>
 
   </body>
 </html>

--- a/test/px-data-grid-navigation-test.js
+++ b/test/px-data-grid-navigation-test.js
@@ -1,0 +1,216 @@
+document.addEventListener('WebComponentsReady', function() {
+  runTests();
+});
+
+function runTests() {
+
+  describe('navigation (paging) component tests', () => {
+
+    let navigation;
+
+    beforeEach((done) => {
+      navigation = fixture('simple-navigation');
+
+      Polymer.RenderStatus.afterNextRender(navigation, () => {
+        setTimeout(() => { // IE11
+          done();
+        });
+      });
+    });
+
+    function getSelectedPageSize() {
+      return Number.parseInt(
+        navigation.shadowRoot.querySelector('.page-size-select px-dropdown')
+          .shadowRoot.querySelector('#label').innerText);
+    }
+
+    function getAvailablePageSizes() {
+      // wrap return in array since querySelectorAll returns node list not an arrays
+      const options = [...navigation.shadowRoot.querySelector('px-dropdown')
+        .shadowRoot.querySelectorAll('.dropdown-option__item')];
+      return options.map((el) => Number.parseInt(el.innerText));
+    }
+
+    function getDisplayedRowRange() {
+      const rangeStr = navigation.shadowRoot.querySelector('.current-rows').innerText.replace(' ', '').split('-');
+      return {
+        min: rangeStr[0].trim(),
+        max: rangeStr[1].trim()
+      };
+    }
+
+    function getArrowElements() {
+      return [...navigation.shadowRoot.querySelectorAll('.arrow')];
+    }
+
+    function isBackArrowDisabled() {
+      return getArrowElements()[0].getAttribute('disabled') !== null;
+    }
+
+    function isNextArrowDisabled() {
+      return getArrowElements()[1].getAttribute('disabled') !== null;
+    }
+
+    function getPageNumbers() {
+      const pageNumberEls = [...navigation.shadowRoot.querySelectorAll('.page-number')];
+      return pageNumberEls.map((el) => Number.parseInt(el.innerText));
+    }
+
+    function getSelectedPageNumber() {
+      return Number.parseInt(navigation.shadowRoot.querySelector('.page-number.selected').innerText);
+    }
+
+    it('should display proper page size', (done) => {
+      // check init page size
+      expect(navigation.pageSize).to.be.eql(getSelectedPageSize());
+      // update page size and check
+      navigation.pageSize = 20;
+      Polymer.flush();
+      expect(navigation.pageSize).to.be.eql(getSelectedPageSize());
+      done();
+    });
+
+    it('should display proper user selectable page sizes', (done) => {
+      // check init page sizes
+      expect(getAvailablePageSizes()).to.be.eql([10, 20, 30]);
+      // update page sizes and check
+      const pageSizes2 = [100, 200, 300];
+      navigation.selectablePageSizes = pageSizes2;
+      Polymer.flush();
+      setTimeout(() => expect(getAvailablePageSizes()).to.be.eql(pageSizes2));
+      done();
+    });
+
+    it('should display proper row ranges', (done) => {
+      expect(getDisplayedRowRange()).to.be.eql({
+        min: '1',
+        max: '10'
+      });
+      // page 2, page size 20
+      navigation.currentPage = 2;
+      navigation.pageSize = 20;
+      Polymer.flush();
+      expect(getDisplayedRowRange()).to.be.eql({
+        min: '21',
+        max: '40'
+      });
+      done();
+    });
+
+    it('should display proper page numbers when first page is selected', (done) => {
+      expect(getPageNumbers()).to.be.eql([1, 2, 3, 4, 5, 6, 7, NaN, 50]);
+      navigation.currentPage = 10;
+      Polymer.flush();
+      expect(getPageNumbers()).to.be.eql([1, NaN, 8, 9, 10, 11, 12, NaN, 50]);
+      navigation.currentPage = 50;
+      Polymer.flush();
+      expect(getPageNumbers()).to.be.eql([1, NaN, 44, 45, 46, 47, 48, 49, 50]);
+      done();
+    });
+
+    it('should display proper selected page number', (done) => {
+      // page 1
+      expect(getSelectedPageNumber()).to.be.eql(1);
+      // page 5
+      navigation.currentPage = 5;
+      Polymer.flush();
+      expect(getSelectedPageNumber()).to.be.eql(5);
+      done();
+    });
+
+    it('should disable back arrow when it is first page', (done) => {
+      // page 1
+      expect(isBackArrowDisabled()).to.be.eql(true);
+      // page 2
+      navigation.currentPage = 2;
+      Polymer.dom.flush();
+      expect(isBackArrowDisabled()).to.be.eql(false);
+      // last page
+      navigation.currentPage = navigation.numberOfPages;
+      Polymer.flush();
+      expect(isBackArrowDisabled()).to.be.eql(false);
+      done();
+    });
+
+    it('should disable next arrow when it is first page', (done) => {
+      // page 1
+      expect(isNextArrowDisabled()).to.be.eql(false);
+      // page 2
+      navigation.currentPage = 2;
+      Polymer.flush();
+      expect(isNextArrowDisabled()).to.be.eql(false);
+      // last page
+      navigation.currentPage = navigation.numberOfPages;
+      Polymer.flush();
+      expect(isNextArrowDisabled()).to.be.eql(true);
+      done();
+    });
+
+    it('should display proper row ranges', (done) => {
+      expect(getDisplayedRowRange()).to.be.eql({
+        min: '1',
+        max: '10'
+      });
+      // page 2, page size 20
+      navigation.currentPage = 2;
+      navigation.pageSize = 20;
+      Polymer.flush();
+      expect(getDisplayedRowRange()).to.be.eql({
+        min: '21',
+        max: '40'
+      });
+      done();
+    });
+
+    it('should display proper page numbers when first page is selected', (done) => {
+      expect(getPageNumbers()).to.be.eql([1, 2, 3, 4, 5, 6, 7, NaN, 50]);
+      navigation.currentPage = 10;
+      Polymer.flush();
+      expect(getPageNumbers()).to.be.eql([1, NaN, 8, 9, 10, 11, 12, NaN, 50]);
+      navigation.currentPage = 50;
+      Polymer.flush();
+      expect(getPageNumbers()).to.be.eql([1, NaN, 44, 45, 46, 47, 48, 49, 50]);
+      done();
+    });
+
+    it('should display proper selected page number', (done) => {
+      // page 1
+      expect(getSelectedPageNumber()).to.be.eql(1);
+      // page 5
+      navigation.currentPage = 5;
+      Polymer.flush();
+      expect(getSelectedPageNumber()).to.be.eql(5);
+      done();
+    });
+
+    it('should disable back arrow when it is first page', (done) => {
+      // page 1
+      expect(isBackArrowDisabled()).to.be.eql(true);
+      // page 2
+      navigation.currentPage = 2;
+      Polymer.dom.flush();
+      expect(isBackArrowDisabled()).to.be.eql(false);
+      // last page
+      navigation.currentPage = navigation.numberOfPages;
+      Polymer.flush();
+      expect(isBackArrowDisabled()).to.be.eql(false);
+      done();
+    });
+
+    it('should disable next arrow when it is first page', (done) => {
+      // page 1
+      expect(isNextArrowDisabled()).to.be.eql(false);
+      // page 2
+      navigation.currentPage = 2;
+      Polymer.flush();
+      expect(isNextArrowDisabled()).to.be.eql(false);
+      // last page
+      navigation.currentPage = navigation.numberOfPages;
+      Polymer.flush();
+      expect(isNextArrowDisabled()).to.be.eql(true);
+      done();
+    });
+
+  });
+
+}

--- a/test/px-data-grid-paginated-test.js
+++ b/test/px-data-grid-paginated-test.js
@@ -1,0 +1,126 @@
+document.addEventListener('WebComponentsReady', function() {
+  runTests();
+});
+
+function runTests() {
+
+  function generateTableData(numRows) {
+    const data = [];
+    for (let i = 0; i < numRows; i++) {
+      data.push({
+        first: 'first-' + i,
+        last: 'last-' + i,
+        email: 'email-' + i + '@stuff.com'
+      });
+    }
+    return data;
+  }
+
+  describe('px-data-grid-paginated component tests', () => {
+
+    let
+      grid,
+      navigation;
+
+    const
+      defaultPageSize = 10,
+      defaultPage = 1,
+      largeTableData = generateTableData(200);
+
+    beforeEach((done) => {
+      grid = fixture('px-data-grid-paginated-fixture');
+      grid.tableData = largeTableData;
+      navigation = grid.shadowRoot.querySelector('px-data-grid-navigation');
+
+      Polymer.RenderStatus.afterNextRender(grid, () => {
+        setTimeout(() => { // IE11
+          done();
+        });
+      });
+    });
+
+    it('should display proper rows with local data', (done) => {
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(defaultPageSize);
+      // test with array shorter than page size
+      grid.tableData = tableData;
+      Polymer.flush();
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(5);
+      done();
+    });
+
+    it('should correctly update rows based on page size', (done) => {
+      // page size 2
+      grid.pageSize = 2;
+      Polymer.flush();
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(2);
+      // page size 4
+      grid.pageSize = 4;
+      Polymer.flush();
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(4);
+      // page size 0
+      grid.pageSize = 0;
+      Polymer.flush();
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(defaultPageSize);
+      // page size -10
+      grid.pageSize = -10;
+      Polymer.flush();
+      expect(getVisibleRows(grid._pxDataGrid).length).to.be.eql(defaultPageSize);
+      done();
+    });
+
+    it('should correctly update rows based on selected page', (done) => {
+      let row,
+        cell,
+        cellText;
+
+      // check first row's first name
+      row = getVisibleRows(grid._pxDataGrid)[0];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[0].first);
+
+      // check last row's first name
+      row = getVisibleRows(grid._pxDataGrid)[grid.pageSize - 1];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[grid.pageSize - 1].first);
+
+      // move to page 5
+      const page = 5;
+      grid.page = page;
+      Polymer.flush();
+
+      // check first row's first name
+      row = getVisibleRows(grid._pxDataGrid)[0];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[(page - 1) * grid.pageSize].first);
+
+      // check last row's first name
+      row = getVisibleRows(grid._pxDataGrid)[grid.pageSize - 1];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[page * grid.pageSize - 1].first);
+
+      // move to invalid page, should set page to 1
+      grid.page = -10;
+      Polymer.flush();
+
+      // check first row's first name
+      row = getVisibleRows(grid._pxDataGrid)[0];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[0].first);
+
+      // check last row's first name
+      row = getVisibleRows(grid._pxDataGrid)[grid.pageSize - 1];
+      cell = getRowCells(row)[0];
+      cellText = getCellContent(grid._pxDataGrid, cell);
+      expect(cellText).to.be.eql(largeTableData[grid.pageSize - 1].first);
+
+      done();
+    });
+
+  });
+
+}


### PR DESCRIPTION
Ready to review and merge if no major problems are found.  Sorry in advance for less than optimal git use and massive PR.

**Major changes/additions/notes:**
 - Removed navigation/paging from the normal grid class.
 - Added wrapper class for paginated grid (px-data-grid-paginated).
 - Added and updated tests for navigation component (UI part of pagination).
 - Tested successfully with local data array and remote data provider from px-data-grid demo.
 - Working will all implemented grid features except for row selection.  Selection works, but toggling it causes some issues.

**Key parts to review:**
 - The px-data-grid-pagination class wraps the supplied data provider (or local data provider) before handing it to the px-data-grid.  This way we can manipulate the params and the callback objects, changing the page, pageSize, items array, and size property when needed.  The wrapper function is _wrapDataProvider.
 - The _wrapDataProvider function sets the original data provider (one passed into the px-data-grid-pagination component or _localDataProvider) to the variable this._baseDataProvider.  This seems strange, but I wasn't able to get it to work otherwise.  I think it has something to do with the context of "this" within the data provider wrapper function.
 - When page is changed, uses vaadinGrid.clearCache() to force new data fetch.  Function is _onNavigationChange.

**Known bugs:** 
 - The VaadinGrid scrollToIndex(index) always goes to bottom of page, no matter the index.  Seems to be related to the data provider wrapper in _wrapDataProvider and how vaadin grid is perceiving the size of its items.

**TODOS:**
 - Add tests for all other grid functionality that will be supported with pagination.  Can we reuse the tests from the normal grid?  Seems redundant to copy them for this wrapper class.