### PR TITLE
Force column update API and changed table actions API

### DIFF
--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -47,9 +47,11 @@
           action-menu="{{props.actionMenu.value}}"
           language="{{props.language.value}}"
           table-actions="{{props.tableActions.value}}"
+          action-menu="{{props.actionMenu.value}}"
           columns="{{props.columns.value}}"
           highlight="{{props.highlight.value}}"
-          auto-filter="{{props.autoFilter.value}}">
+          auto-filter="{{props.autoFilter.value}}"
+          on-table-action="tableActionListener">
         </px-data-grid>
       </px-demo-component>
       <!-- END Component ------------------------------------------------------>
@@ -573,9 +575,7 @@
         defaultValue: [
           {
             name: 'Export CSV',
-            action: function() {
-              window.alert('TODO');
-            }
+            id: 'CSV'
           }
         ],
         inputType: 'code:JSON'
@@ -593,6 +593,10 @@
         });
         grid.updateColumns();
       }
+    },
+
+    tableActionListener: function(evt) {
+      window.alert('Table Action ' + evt.detail.id);
     },
 
     observers: [

--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -131,6 +131,7 @@
                 {
                   first: 'Elizabeth',
                   last: 'Wong',
+                  full: 'Elizabeth Wong',
                   email: 'sika@iknulber.cl',
                   age: 32
                 },
@@ -416,6 +417,7 @@
         }
       },
     },
+
     /**
      * A reference for `this.props`. Read the documentation there.
      */
@@ -426,6 +428,7 @@
           {
             first: 'Elizabeth',
             last: 'Wong',
+            full: 'Elizabeth Wong',
             email: 'sika@iknulber.cl',
             age: 23
           },
@@ -466,13 +469,11 @@
             type: 'number',
             width: '50px',
             flexGrow: 0,
-            value: (item) => {
-              return item.age;
-            }
+            hidden: false
           },
           {
             name: 'Full Name',
-            path: '',
+            path: 'full',
             hidden: true
           },
           {
@@ -556,6 +557,13 @@
             condition: (cellContent, column, item) => {
               return cellContent == 'Elizabeth';
             }
+          },
+          {
+            type: 'cell',
+            color: '#88F',
+            condition: (cellContent, column, item) => {
+              return cellContent == 'Dennis';
+            }
           }
         ]
       },
@@ -572,6 +580,23 @@
         ],
         inputType: 'code:JSON'
       }
-    }
+    },
+
+    _fullNameChanged() {
+      const grid = this.shadowRoot.querySelector('px-data-grid');
+      if (grid && grid.columns) {
+        const hidden = this.props.hideFullName.value;
+        const frozen = this.props.freezeFullName.value;
+        grid.columns.filter(c => c.name == 'Full Name').forEach(c => {
+          c.hidden = hidden;
+          c.frozen = frozen;
+        });
+        grid.updateColumns();
+      }
+    },
+
+    observers: [
+      '_fullNameChanged(props.hideFullName.value, props.freezeFullName.value)'
+    ]
   });
 </script>

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -61,11 +61,13 @@
             multi-sort="{{props.multiSort.value}}"
             column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
             action-menu="{{props.actionMenu.value}}"
+            table-actions="{{props.tableActions.value}}"
             language="{{props.language.value}}"
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
-            pagination="{{props.pagination.value}}">
+            pagination="{{props.pagination.value}}"
+            on-table-action="tableActionListener">
         </px-data-grid>
 
         <dom-if if="[[selectedItems.length]]">
@@ -116,6 +118,10 @@
       if (this.hoveredCellData === evt.detail.cellContent) {
         this.hoveredCellData = '';
       }
+    },
+
+    tableActionListener: function(evt) {
+      window.alert('Table Action ' + evt.detail.id);
     },
 
     properties: {
@@ -526,6 +532,17 @@
         value: 'en',
         inputType: 'dropdown',
         inputChoices: ['en', 'fr', 'fi']
+      },
+
+      tableActions: {
+        type: Object,
+        defaultValue: [
+          {
+            name: 'Export CSV',
+            id: 'CSV'
+          }
+        ],
+        inputType: 'code:JSON'
       }
     },
 

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -354,7 +354,10 @@
             },
 
             /**
-             * All custom table actions. Should return array of objects with 'name' (String) and 'action' (function).
+             * All custom table actions shown before columns. Arrays should contain objects
+             * with name (String, shown to user) and id (String, given back in event).
+             * When user selects these actions table-action event will be emitted, with id of
+             * action at event.detail.id
              */
             tableActions: {
               type: Array,
@@ -503,10 +506,6 @@
           if (dataColumns.length) {
             this._vaadinGrid.insertBefore(event.detail.column, dataColumns[0]);
           }
-        }
-
-        _columnsChanged(columns) {
-          console.log('columns changed');
         }
 
         /**
@@ -691,16 +690,21 @@
           const item = evt.detail.detail.item;
           const key = item.key;
 
-          if (key) {
+          if (key && typeof key == 'string') {
             // -column- is temporary work around to limitations of px-dropdown
-            if (typeof key == 'string' && key.startsWith('-column-')) {
+            if (key.startsWith('-column-')) {
               const columnName = key.substr('-column-'.length);
               this._getColumnsWithName(columnName).forEach((c) => {
                 c.hidden = c.hidden === undefined ? true : !c.hidden;
               });
-            // function callbacks are stored as object with action function
-            } else if (typeof key == 'object' && key.action && typeof key.action == 'function') {
-              key.action();
+            } else if (key.startsWith('-action-')) {
+              const actionId = key.substr('-action-'.length);
+              this.dispatchEvent(new CustomEvent('table-action', {
+                detail: {
+                  id: actionId
+                },
+                bubbles: true
+              }));
             }
           }
         }
@@ -733,9 +737,7 @@
           if (this.tableActions) {
             this.tableActions.forEach((item) => {
               content.push({
-                key: {
-                  action: item.action
-                },
+                key: '-action-' + item.id,
                 val: item.name,
                 selected: false,
                 disabled: true

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -111,6 +111,7 @@
           language="[[language]]"
           resources="[[resources]]"
           type="[[column.type]]"
+          frozen="[[column.frozen]]"
           mapped-object="[[column]]"
           width="[[_getColumnWidth(column)]]"
           flex-grow="[[_getColumnFlexGrow(column)]]"
@@ -466,6 +467,17 @@
           };
         }
 
+        updateColumns() {
+          const probs = ['hidden', 'name', 'frozen', 'width', 'flexGrow', 'path'];
+          for (let i = 0; i < this.columns.length; ++i) {
+            const prefix = 'columns.' + i + '.';
+            probs.forEach(prob => {
+              const path = prefix + prob;
+              this.notifyPath(path);
+            });
+          }
+        }
+
         ready() {
           super.ready();
           this._vaadinGrid = this.shadowRoot.querySelector('vaadin-grid');
@@ -491,6 +503,10 @@
           if (dataColumns.length) {
             this._vaadinGrid.insertBefore(event.detail.column, dataColumns[0]);
           }
+        }
+
+        _columnsChanged(columns) {
+          console.log('columns changed');
         }
 
         /**

--- a/test/columns-api.js
+++ b/test/columns-api.js
@@ -18,12 +18,20 @@ document.addEventListener('WebComponentsReady', () => {
     });
 
     describe('manually passed columns', () => {
-      const columns = [
+      const columnsA = [
         {
           name: 'first',
           header: 'First Name',
           path: 'first'
         },
+        {
+          header: 'Hidden column',
+          hidden: true,
+          path: ''
+        }
+      ];
+
+      const columnsB = [
         {
           name: 'last',
           header: 'Last Name',
@@ -41,11 +49,70 @@ document.addEventListener('WebComponentsReady', () => {
         }
       ];
 
-      it('should change generated column to manually passed', () => {
-        grid.columns = columns;
+      it('should change generated no columns to manually passed', () => {
+
+        // Check that no columns as no data, then set first columns
+        let currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+        expect(currentColumns.length).to.be.eq(0);
+        grid.columns = columnsA;
         flushVaadinGrid(grid);
-        expect(grid._vaadinGrid.querySelectorAll('px-data-grid-column').length).to.be.eq(4);
+
+        // Verify columns set correctly and set new columns
+        currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+        expect(currentColumns.length).to.be.eq(2);
+        expect(currentColumns[0].name).to.be.eq('first');
+        grid.columns = columnsB;
+        flushVaadinGrid(grid);
+
+        // Verify columns set correct and then modify columns and update
+        currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+        expect(currentColumns.length).to.be.eq(3);
+        expect(currentColumns[0].name).to.be.eq('last');
       });
+    });
+
+    it('should be handle column data update with updateColumns', () => {
+      const columnsA = [
+        {
+          name: 'last',
+          header: 'Last Name',
+          path: 'last'
+        },
+        {
+          name: 'email',
+          header: 'Email',
+          path: 'email'
+        },
+        {
+          header: 'Hidden column',
+          hidden: true,
+          path: ''
+        }
+      ];
+
+      // Should not have columns at the start
+      let currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+      expect(currentColumns.length).to.be.eq(0);
+      grid.columns = columnsA;
+      flushVaadinGrid(grid);
+
+      // Modfy data and call updateColumns
+      currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+      expect(currentColumns.length).to.be.eq(columnsA.length);
+      expect(currentColumns[0].name).to.be.eq(columnsA[0].name);
+      expect(currentColumns[1].name).to.be.eq(columnsA[1].name);
+      const modifiedColumns = grid.columns.slice();
+      modifiedColumns[0].hidden = true;
+      modifiedColumns[0].name = 'Modified';
+      grid.columns = modifiedColumns;
+      grid.updateColumns();
+      flushVaadinGrid(grid);
+
+      // Finally verify column modifications
+      currentColumns = grid._vaadinGrid.querySelectorAll('px-data-grid-column');
+      expect(currentColumns.length).to.be.eq(3);
+      expect(currentColumns[0].name).to.be.eq('Modified');
+      expect(currentColumns[0].hidden).to.be.eq(true);
     });
   });
 });


### PR DESCRIPTION
I added updateColumns API to tell px-grid to really update columns, as updating arrays is real pain with polymer sometimes.

Also added new API for table actions. No functions, just ids and then table-action events. This to work around no functions in JSON limitation.