### PR TITLE
Call _populateTableColumns internally after receiving a new set of data

### DIFF
--- a/demo/px-data-grid-remote-data-provider-demo.html
+++ b/demo/px-data-grid-remote-data-provider-demo.html
@@ -151,13 +151,8 @@
           xhr.onload = () => {
             const size = parseInt(xhr.getAllResponseHeaders().match(/x-total-count: (\d+)/)[1]);
             callback(JSON.parse(xhr.responseText), size);
-
-            // TODO: @limonte this should be moved to internal functionality
-            document.querySelector('local-element-demo')
-              .shadowRoot.querySelector('px-demo-collection')
-              .shadowRoot.querySelector('px-data-grid-remote-data-provider-demo')
-              .shadowRoot.querySelector('px-data-grid')._populateTableColumns(JSON.parse(xhr.responseText));
           };
+
           let url = 'https://px-data-grid-dummy-backend.herokuapp.com/contacts?' +
             '_page=' + encodeURIComponent(params.page + 1) + '&' +
             '_limit=' + encodeURIComponent(params.pageSize);

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -654,10 +654,12 @@
         _tableDataChanged(tableData) {
           if (tableData) {
             this._currentDataProvider = (params, callback) => {
-              this._localDataProvider(params, callback);
+              this._localDataProvider(params, (items, size) => {
+                callback(items, size);
+                this._populateTableColumns(items);
+              });
             };
             this._hasLocalDataProvider = true;
-            this._populateTableColumns(tableData);
           }
         }
 
@@ -734,7 +736,12 @@
 
         _remoteDataProviderChanged(provider) {
           this._hasLocalDataProvider = false;
-          this._currentDataProvider = provider;
+          this._currentDataProvider = (params, callback) => {
+            provider(params, (items, size) => {
+              callback(items, size);
+              this._populateTableColumns(items);
+            });
+          };
         }
 
         _resolveColumnPath(column) {


### PR DESCRIPTION
Resolving one of my tech debts related to the remote data provider.

`_populateTableColumns()` is now called internally, as it should. 