### PR TITLE
adding simple auto height flag to grid

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -66,6 +66,7 @@
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
+            auto-height="{{props.autoHeight.value}}"
             on-table-action="tableActionListener">
         </px-data-grid>
 
@@ -510,6 +511,12 @@
       },
 
       resizable: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
+      },
+
+      autoHeight: {
         type: Boolean,
         defaultValue: false,
         inputType: 'toggle'

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -93,6 +93,10 @@
         content: ")";
         display: inline;
       }
+
+      vaadin-grid.auto-height {
+        height: auto;
+      }
     </style>
 
     <template is="dom-if" if="{{filterable}}">
@@ -529,6 +533,21 @@
               value: function() {
                 return [];
               }
+            },
+
+            /**
+             * Grid auto resize height to match number of rows.
+             */
+            autoHeight: {
+              type: Boolean,
+              value: false,
+              observer: '_autoHeightChanged'
+            },
+
+            _autoHeightClass: {
+              type: String,
+              value: 'auto-height',
+              readOnly: true
             }
           };
         }
@@ -1158,6 +1177,20 @@
           this.set('_filterHighlights', filterHighlights);
 
           this._vaadinGrid.clearCache();
+        }
+
+        _autoHeightChanged(autoHeight) {
+          if (!this._vaadinGrid) {
+            return;
+          }
+          if (autoHeight) {
+            this._vaadinGrid.classList.add(this._autoHeightClass);
+          } else {
+            this._vaadinGrid.classList.remove(this._autoHeightClass);
+          }
+          if (this._vaadinGrid) {
+            Polymer.RenderStatus.afterNextRender(this._vaadinGrid, () => this._vaadinGrid.notifyResize());
+          }
         }
       }
       customElements.define(DataGridElement.is, DataGridElement);

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -94,7 +94,7 @@
         display: inline;
       }
 
-      vaadin-grid.auto-height {
+      :host([auto-height]) vaadin-grid {
         height: auto;
       }
     </style>
@@ -541,13 +541,8 @@
             autoHeight: {
               type: Boolean,
               value: false,
+              reflectToAttribute: true,
               observer: '_autoHeightChanged'
-            },
-
-            _autoHeightClass: {
-              type: String,
-              value: 'auto-height',
-              readOnly: true
             }
           };
         }
@@ -1183,14 +1178,8 @@
           if (!this._vaadinGrid) {
             return;
           }
-          if (autoHeight) {
-            this._vaadinGrid.classList.add(this._autoHeightClass);
-          } else {
-            this._vaadinGrid.classList.remove(this._autoHeightClass);
-          }
-          if (this._vaadinGrid) {
-            Polymer.RenderStatus.afterNextRender(this._vaadinGrid, () => this._vaadinGrid.notifyResize());
-          }
+
+          Polymer.RenderStatus.afterNextRender(this._vaadinGrid, () => this._vaadinGrid.notifyResize());
         }
       }
       customElements.define(DataGridElement.is, DataGridElement);


### PR DESCRIPTION
PR for https://github.com/vaadin/px-data-grid/issues/144

Simple boolean property that toggles ‘height: auto’ on vaadin grid.  This makes the grids height automatically match the number of rows.

