### PR TITLE
Include styles into component

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,13 +47,9 @@
     <!--
       Load theme files, apply default theme.
     -->
-    <link rel="import" href="css/px-data-grid-styles.html">
     <link rel="import" href="css/px-data-grid-dark-theme-styles.html">
     <link rel="import" href="css/px-data-grid-light-theme-styles.html">
 
-    <custom-style>
-      <style include="px-data-grid-styles" is="custom-style"></style>
-    </custom-style>
     <custom-style id="px-data-grid-theme-styles">
       <style include="px-data-grid-light-theme-styles" is="custom-style"></style>
     </custom-style>

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -15,9 +15,11 @@
 <link rel="import" href="px-data-grid-cell-content-wrapper.html">
 <link rel="import" href="px-data-grid-filter.html">
 
+<link rel="import" href="css/px-data-grid-styles.html">
+
 <dom-module id="px-data-grid">
   <template>
-    <style>
+    <style include="px-data-grid-styles">
       :host {
         position: relative;
         display: block;


### PR DESCRIPTION
Styles for data-grid are moved from `demo/index.html` to the component by itself.

Working jsfiddle with the `include-styles-into-component` branch dependency: https://jsfiddle.net/6r5htd05/89/