### PR TITLE
fix(selection-column): get rid of .selection-count, use vaadin-checkbox label instead

### DIFF
--- a/px-data-grid-selection-column.html
+++ b/px-data-grid-selection-column.html
@@ -3,14 +3,30 @@
 <link rel="import" href="../vaadin-checkbox/vaadin-checkbox.html">
 <link rel="import" href="../vaadin-radio-button/vaadin-radio-button.html">
 
+<dom-module id="vaadin-checkbox-styles" theme-for="vaadin-checkbox">
+  <template>
+    <style>
+      [part=wrapper] {
+        display: flex;
+        align-items: center;
+        outline: none;
+      }
+
+      #nativeCheckbox {
+        margin: 0;
+      }
+    </style>
+  </template>
+</dom-module>
+
 <dom-module id="px-data-grid-selection-column">
   <template>
     <template class="header" id="defaultHeaderTemplate">
       <template is="dom-if" if="[[multiSelect]]">
         <vaadin-checkbox class="select-all-checkbox" aria-label="Select All" hidden$="[[_selectAllHidden]]" on-checked-changed="_onSelectAllCheckedChanged"
           checked="[[_isChecked(selectAll, _indeterminate)]]" indeterminate="[[_indeterminate]]">
+          ([[_selectionCount]])
         </vaadin-checkbox>
-        <div class="selection-count">[[_selectionCount]]</div>
       </template>
     </template>
     <template id="defaultBodyTemplate">

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -68,31 +68,11 @@
 
       vaadin-checkbox {
         height: 15px;
-        margin-top: -3px;
       }
 
       vaadin-radio-button {
         height: 12px;
         width: 12px;
-      }
-
-      .selection-count {
-        color: var(--px-data-grid-header-text-color);
-        font-size: var(--px-data-grid-header-font-size);
-        position: absolute;
-        left: calc(var(--px-data-grid-padding-left) + 20px);
-        bottom: 5px;
-        pointer-events: none;
-      }
-
-      .selection-count::before {
-        content: "(";
-        display: inline;
-      }
-
-      .selection-count::after {
-        content: ")";
-        display: inline;
       }
 
       :host([auto-height]) vaadin-grid {


### PR DESCRIPTION
Fixes #196 #197 

Tested manually in IE11, Firefox and Chrome, the look-n-feel is now the same for all browsers.
