### PR TITLE
fix(header-cells): fix header cells height for IE11, set it to 35px according to specs

### DIFF
--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -10,6 +10,7 @@
         display: flex;
         flex: 1;
         align-items: center;
+        padding-top: 10px;
         --px-dropdown-toggle-icon-size: 12px;
         margin-left: calc(0px - var(--px-dropdown-toggle-icon-size));
       }

--- a/px-data-grid-theme.html
+++ b/px-data-grid-theme.html
@@ -123,8 +123,9 @@
 
       [part~="header-cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content),
       [part~="footer-cell"]:not([part~="details-cell"]) ::slotted(vaadin-grid-cell-content) {
-        padding-top: 6px;
-        padding-bottom: 5px;
+        padding-top: 0;
+        padding-bottom: 0;
+        height: 35px;
       }
 
       [part~="reorder-ghost"] {


### PR DESCRIPTION
Fixes #179

Tested manually in IE11, Firefox and Chrome, the look-n-feel is now the same for all browsers.