### PR TITLE
fix(custom-column): add JSON.stringify(column) to warning message

### DIFF
--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -938,7 +938,7 @@
 
         _resolveColumnPath(column) {
           if (typeof column.path === 'undefined') {
-            console.warn(`column.path for column ${column.name} should be initialized.`);
+            console.warn(`column.path for column ${JSON.stringify(column)} should be initialized.`);
           }
           return column.path ? column.path : '';
         }


### PR DESCRIPTION
Fixes #105 

`column.name` could be undefined as well, we shouldn't rely on it. Instead, print the whole `column` object.