### PR TITLE
When resorting while in edit, do not show fields at wrong row

### DIFF
--- a/px-data-grid-cell-content-wrapper.html
+++ b/px-data-grid-cell-content-wrapper.html
@@ -33,6 +33,11 @@
               observer: '_cellColorChanged'
             },
 
+            _itemWas: {
+              type: Object,
+              value: undefined
+            },
+
             localize: Function,
 
             _valueElement: Element
@@ -122,7 +127,10 @@
             return;
           }
 
-          if (!this._valueElement && renderer) {
+          const newItem = this._itemWas && item !== this._itemWas;
+          this._itemWas = item;
+
+          if ((!this._valueElement || newItem) && renderer) {
             this._valueElement = document.createElement(renderer);
             this._valueElement.addEventListener('value-changed', this._boundValueChangedListener);
             this._valueElement.column = this.column;

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1373,6 +1373,9 @@
          * current version in vaadin-grid-sort-mixin, and replace unshift with push.
          */
         _onPxSorterChanged(e) {
+
+          this._pxDataGrid._editingItem = null;
+
           const sorter = e.target;
 
           this._removeArrayItem(this._sorters, sorter);


### PR DESCRIPTION
Fixes #263