### PR TITLE
Add sudo: true to Travis config for running chrome-sandbox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 dist: trusty
 language: node_js
 node_js: 8.1


### PR DESCRIPTION
Current master is failing: https://travis-ci.org/vaadin/px-data-grid/builds/326384940

Reason: https://github.com/travis-ci/travis-ci/issues/8836#issuecomment-356362524

![](https://i.imgur.com/WYLgV7j.png)

`chrome-sandbox` needs `sudo` in order to run :this-is-fine:
  