### PR TITLE
Use flex-start, not center as default align of cell content

### DIFF
--- a/sass/px-data-grid.scss
+++ b/sass/px-data-grid.scss
@@ -21,7 +21,7 @@ px-data-grid-cell-content-wrapper {
   padding-right: var(--px-data-grid-padding-right);
   min-height: 100%;
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   background-color: var(--px-data-grid-cell-dragging-color, var(--px-data-grid-highlight-background-color, transparent));
   line-height: 16px;
 }


### PR DESCRIPTION
Fixes #307