### PR TITLE
API CHANGE, replace auto-height with grid-height

### DIFF
--- a/css/px-data-grid-selection-column-styles.html
+++ b/css/px-data-grid-selection-column-styles.html
@@ -1,7 +1,7 @@
 <dom-module id="px-data-grid-selection-column-styles">
 <template>
 <style>
-[part=wrapper]{display:flex;align-items:center;outline:0}[part=native-checkbox],[part=native-radio]{margin:0}
+[part=wrapper]{display:flex;align-items:center;outline:0}[part=native-checkbox],[part=native-radio]{margin:0}[part=label]{margin-left:5px}
 </style>
 </template>
 </dom-module>

--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -622,9 +622,9 @@
 
       gridHeight: {
         type: String,
-        defaultValue: '300px',
+        defaultValue: 'default',
         inputType: 'dropdown',
-        inputChoices: ['auto', '300px', '600px', '900px']
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
 
       actionMenu: {

--- a/demo/px-data-grid-column-demo.html
+++ b/demo/px-data-grid-column-demo.html
@@ -48,7 +48,7 @@
           action-menu="{{props.actionMenu.value}}"
           language="{{props.language.value}}"
           striped="{{props.striped.value}}"
-          auto-height="{{props.autoHeight.value}}"
+          grid-height="{{props.gridHeight.value}}"
           table-actions="{{props.tableActions.value}}"
           action-menu="{{props.actionMenu.value}}"
           columns="{{props.columns.value}}"
@@ -620,10 +620,11 @@
         inputType: 'toggle'
       },
 
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: '300px',
+        inputType: 'dropdown',
+        inputChoices: ['auto', '300px', '600px', '900px']
       },
 
       actionMenu: {

--- a/demo/px-data-grid-custom-renderer-demo.html
+++ b/demo/px-data-grid-custom-renderer-demo.html
@@ -79,7 +79,7 @@
             selection-mode="{{props.selectionMode.value}}"
             multi-selected="{{props.multiSelect.value}}"
             columns="{{props.columns.value}}"
-            auto-height="{{props.autoHeight.value}}"
+            grid-height="{{props.gridHeight.value}}"
             column-reordering-allowed="{{props.columnReorderingAllowed.value}}">
         </px-data-grid>
       </px-demo-component>
@@ -212,10 +212,11 @@
         defaultValue: false,
         inputType: 'toggle'
       },
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
       selectionMode: {
         type: String,

--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -70,7 +70,7 @@
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
-            auto-height="{{props.autoHeight.value}}"
+            grid-height="{{props.gridHeight.value}}"
             on-table-action="tableActionListener">
         </px-data-grid>
 
@@ -547,10 +547,11 @@
         inputType: 'toggle'
       },
 
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
 
       striped: {

--- a/demo/px-data-grid-highlight-demo.html
+++ b/demo/px-data-grid-highlight-demo.html
@@ -45,7 +45,7 @@
             selection-mode="{{props.selectionMode.value}}"
             multi-selected="{{props.multiSelect.value}}"
             highlight="{{props.highlight.value}}"
-            auto-height="{{props.autoHeight.value}}"
+            grid-height="{{props.gridHeight.value}}"
             column-reordering-allowed="{{props.columnReorderingAllowed.value}}">
         </px-data-grid>
       </px-demo-component>
@@ -201,10 +201,11 @@
         defaultValue: false,
         inputType: 'toggle'
       },
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
       selectionMode: {
         type: String,

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -65,7 +65,7 @@
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
-            auto-height="{{props.autoHeight.value}}">
+            grid-height="{{props.gridHeight.value}}">
         </px-data-grid-paginated>
 
         <dom-if if="[[selectedItems.length]]">
@@ -479,10 +479,11 @@
         inputType: 'toggle'
       },
 
-      autoHeight: {
-        type: Boolean,
-        defaultValue: true,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
 
       striped: {

--- a/demo/px-data-grid-remote-data-provider-demo.html
+++ b/demo/px-data-grid-remote-data-provider-demo.html
@@ -56,7 +56,7 @@
             hide-selection-column="{{props.hideSelectionColumn.value}}"
             resizable="{{props.resizable.value}}"
             striped="{{props.striped.value}}"
-            auto-height="{{props.autoHeight.value}}"
+            grid-height="{{props.gridHeight.value}}"
             multi-sort="{{props.multiSort.value}}"
             column-reordering-allowed="{{props.columnReorderingAllowed.value}}"
             action-menu="{{props.actionMenu.value}}"
@@ -236,10 +236,11 @@
         inputType: 'toggle'
       },
 
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
 
       language: {

--- a/demo/px-data-grid-row-details-demo.html
+++ b/demo/px-data-grid-row-details-demo.html
@@ -66,7 +66,7 @@
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
-            auto-height="{{props.autoHeight.value}}"
+            grid-height="{{props.gridHeight.value}}"
             on-table-action="tableActionListener"
             row-details="{{props.rowDetails.value}}">
 
@@ -289,10 +289,11 @@
         inputType: 'toggle'
       },
 
-      autoHeight: {
-        type: Boolean,
-        defaultValue: false,
-        inputType: 'toggle'
+      gridHeight: {
+        type: String,
+        defaultValue: 'default',
+        inputType: 'dropdown',
+        inputChoices: ['default', 'auto', '300px', '600px', '900px']
       },
 
       striped: {

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -30,7 +30,7 @@
       action-menu="{{actionMenu}}"
       language="{{language}}"
       auto-filter="{{autoFilter}}"
-      auto-height="{{autoHeight}}"
+      grid-height="{{gridHeight}}"
       item-id-path="{{itemIdPath}}">
     </px-data-grid>
 
@@ -348,9 +348,9 @@
             /**
              * Grid auto resize height to match number of rows.
              */
-            autoHeight: {
-              type: Boolean,
-              value: true
+            gridHeight: {
+              type: String,
+              value: 'auto'
             },
 
             /**

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -586,7 +586,7 @@
             /**
              * Define height of grid. If 'auto' the height of grid will match with
              * match with number of rows in grid. Undefined value and 'default'
-             * will use default hight. Any other value (eg. '400px') is given as
+             * will use default height. Any other value (eg. '400px') is given as
              * CSS height value to the actual grid component inside px-data-grid.
              */
             gridHeight: {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -90,8 +90,8 @@
                  selected-items="{{selectedItems}}"
                  multi-sort="[[multiSort]]"
                  item-id-path="[[itemIdPath]]"
-                 auto-height$="[[autoHeight]]"
                  page-size="{{pageSize}}"
+                 auto-height$="[[_isAutoHeight(gridHeight)]]"
                  loading="{{_loading}}">
 
       <template is="dom-if" if="[[_isSelectable(selectionMode)]]" restamp>
@@ -584,13 +584,15 @@
             },
 
             /**
-             * Grid auto resize height to match number of rows.
+             * Define height of grid. If 'auto' the height of grid will match with
+             * match with number of rows in grid. Undefined value and 'default'
+             * will use default hight. Any other value (eg. '400px') is given as
+             * CSS height value to the actual grid component inside px-data-grid.
              */
-            autoHeight: {
-              type: Boolean,
-              value: false,
+            gridHeight: {
+              type: String,
               reflectToAttribute: true,
-              observer: '_autoHeightChanged'
+              observer: '_gridHeightChanged'
             },
 
             /**
@@ -1359,9 +1361,18 @@
           this._vaadinGrid.clearCache();
         }
 
-        _autoHeightChanged(autoHeight) {
+        _gridHeightChanged(gridHeight) {
           if (!this._vaadinGrid) {
             return;
+          }
+
+          // In case of real undefined (or 'default' string, for demo cases)
+          // and 'auto' the CSS height of vaadin-grid is set to undefined. Other
+          // values are set as CSS height value to vaadin-grid.
+          if (!this.gridHeight || this.gridHeight == 'default' || this.gridHeight == 'auto') {
+            this._vaadinGrid.style.height = null;
+          } else {
+            this._vaadinGrid.style.height = this.gridHeight;
           }
 
           Polymer.RenderStatus.afterNextRender(this._vaadinGrid, () => this._vaadinGrid.notifyResize());
@@ -1614,6 +1625,10 @@
 
         _copyArray(arr) {
           return JSON.parse(JSON.stringify(arr));
+        }
+
+        _isAutoHeight() {
+          return this.gridHeight === 'auto';
         }
 
         getState() {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1627,8 +1627,8 @@
           return JSON.parse(JSON.stringify(arr));
         }
 
-        _isAutoHeight() {
-          return this.gridHeight === 'auto';
+        _isAutoHeight(gridHeight) {
+          return gridHeight === 'auto';
         }
 
         getState() {


### PR DESCRIPTION
New attribute to allow define the height of actual grid inside
px-data-grid. Currently supported values are undefined and
'default' both just using the default heigth of vaadin-grid. Then
'auto' that is as old auto-height. And then any non-relative
CSS height value (eg. '300px'). This does not yet support pairing
sizing with define height of px-data-grid. That is new requirement
and needs to be done later.

Fixes #333