### PR TITLE
Add missing documentation and property to demo

### DIFF
--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -65,6 +65,7 @@
             auto-filter="{{props.autoFilter.value}}"
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
+            selectable-page-sizes="{{props.selectablePageSizes.value}}"
             grid-height="{{props.gridHeight.value}}">
         </px-data-grid-paginated>
 
@@ -490,6 +491,12 @@
         type: Boolean,
         defaultValue: false,
         inputType: 'toggle'
+      },
+
+      selectablePageSizes: {
+        type: Array,
+        value: [10, 20, 30],
+        inputType: 'code:JSON'
       },
 
       language: {

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -32,7 +32,7 @@
 
     <!-- Header -->
     <px-demo-header
-        module-name="px-data-grid"
+        module-name="px-data-grid-paginated"
         description="The Data Grid component is useful for displaying tabular data, and provides more functionality than a simple table."
         mobile desktop tablet>
     </px-demo-header>
@@ -91,13 +91,13 @@
       <px-demo-component-snippet
           slot="px-demo-component-snippet"
           element-properties="{{props}}"
-          element-name="px-data-grid"
+          element-name="px-data-grid-paginated"
           links-includes="[[linksIncludes]]">
       </px-demo-component-snippet>
     </px-demo-interactive>
 
     <!-- API Viewer -->
-    <px-demo-api-viewer source="px-data-grid" api-source-file-path="px-data-grid-api.json"></px-demo-api-viewer>
+    <px-demo-api-viewer source="px-data-grid-paginated" api-source-file-path="px-data-grid-paginated-api.json"></px-demo-api-viewer>
 
     <!-- Footer -->
     <px-demo-footer></px-demo-footer>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,9 +111,13 @@ gulp.task('generate-api', function(cb) {
   exec(`node_modules/.bin/polymer analyze ${pkg.name}.html > ${pkg.name}-api.json`, function(err, stdout, stderr) {
     stdout && console.log(stdout); // eslint-disable-line
     stderr && console.log(stderr); // eslint-disable-line
-    cb(err);
-  });
 
+    exec(`node_modules/.bin/polymer analyze px-data-grid-paginated.html > px-data-grid-paginated-api.json`, function(err, stdout, stderr) {
+      stdout && console.log(stdout); // eslint-disable-line
+      stderr && console.log(stderr); // eslint-disable-line
+      cb(err);
+    });
+  });
 });
 
 gulp.task('watch', function() {

--- a/px-data-grid-paginated-api.json
+++ b/px-data-grid-paginated-api.json
@@ -1,0 +1,24497 @@
+{
+  "schema_version": "1.0.0",
+  "namespaces": [
+    {
+      "name": "Predix",
+      "description": "",
+      "summary": "",
+      "sourceRange": {
+        "file": "px-data-grid-paginated.html",
+        "start": {
+          "line": 552,
+          "column": 6
+        },
+        "end": {
+          "line": 552,
+          "column": 42
+        }
+      },
+      "elements": [
+        {
+          "description": "A `<px-data-grid-column>` is used to configure how a column in `<px-data-grid>`\nshould look like by using HTML templates.\nA column can have a template for each of the three table sections: header, body and footer.\n\nThe `class` attribute is used to differentiate header and footer templates from the body template.\n\n#### Example:\n```html\n<px-data-grid-column>\n  <template class=\"header\">I'm in the header</template>\n  <template>I'm in the body</template>\n  <template class=\"footer\">I'm in the footer</template>\n</px-data-grid-column>\n```",
+          "summary": "",
+          "path": "px-data-grid-column.html",
+          "properties": [
+            {
+              "name": "resizable",
+              "type": "boolean",
+              "description": "When set to true, the column is user-resizable.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 24,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "headerTemplate",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 43,
+                  "column": 8
+                },
+                "end": {
+                  "line": 45,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "footerTemplate",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 52,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "frozen",
+              "type": "boolean",
+              "description": "When true, the column is frozen. When a column inside of a column group is frozen,\nall of the sibling columns inside the group will get frozen also.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 61,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "hidden",
+              "type": "boolean",
+              "description": "When set to true, the cells for this column are hidden.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 66,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_lastFrozen",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 70,
+                  "column": 8
+                },
+                "end": {
+                  "line": 73,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_order",
+              "type": "number",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 75,
+                  "column": 8
+                },
+                "end": {
+                  "line": 75,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_reorderStatus",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 77,
+                  "column": 8
+                },
+                "end": {
+                  "line": 77,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_emptyCells",
+              "type": "Array",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 79,
+                  "column": 8
+                },
+                "end": {
+                  "line": 79,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_headerCell",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 81,
+                  "column": 8
+                },
+                "end": {
+                  "line": 81,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_footerCell",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 83,
+                  "column": 8
+                },
+                "end": {
+                  "line": 83,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_grid",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 85,
+                  "column": 8
+                },
+                "end": {
+                  "line": 85,
+                  "column": 21
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "width",
+              "type": "string",
+              "description": "Width of the cells for this column.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 382,
+                  "column": 10
+                },
+                "end": {
+                  "line": 385,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"100px\"",
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "flexGrow",
+              "type": "number",
+              "description": "Flex grow ratio for the cell widths. When set to 0, cell width is fixed.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 390,
+                  "column": 10
+                },
+                "end": {
+                  "line": 393,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "1",
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "template",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 398,
+                  "column": 10
+                },
+                "end": {
+                  "line": 400,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "_cells",
+              "type": "Array",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 402,
+                  "column": 10
+                },
+                "end": {
+                  "line": 402,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of column is used on table action menu to offer hide/show functionality. As headers are fully optional\nand might not even contain the name of column, this separate value is required if you use table action menu.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 39,
+                  "column": 12
+                },
+                "end": {
+                  "line": 41,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path of column is used for the 'Group by column' functionality.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 46,
+                  "column": 12
+                },
+                "end": {
+                  "line": 48,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "mappedObject",
+              "type": "Object",
+              "description": "Just a trick to map generated column instance to matching data object.\nCan be also used to update object when properties change.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 54,
+                  "column": 12
+                },
+                "end": {
+                  "line": 57,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_mappedObjectChanged\""
+                }
+              }
+            },
+            {
+              "name": "_headerCellContentWrapper",
+              "type": "Element",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 59,
+                  "column": 12
+                },
+                "end": {
+                  "line": 61,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Type of the column. Can be string, number or date.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 66,
+                  "column": 12
+                },
+                "end": {
+                  "line": 70,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_typeChanged\""
+                }
+              },
+              "defaultValue": "\"string\""
+            },
+            {
+              "name": "_permittedTypes",
+              "type": "Array",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 72,
+                  "column": 12
+                },
+                "end": {
+                  "line": 75,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "[\"string\",\"number\",\"date\"]"
+            },
+            {
+              "name": "isDataColumn",
+              "type": "boolean",
+              "description": "Just to help to identify columns with data",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 80,
+                  "column": 12
+                },
+                "end": {
+                  "line": 83,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "isRemoteDataProvider",
+              "type": "boolean",
+              "description": "If true, the grid is in the remote-data-provider mode",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 88,
+                  "column": 12
+                },
+                "end": {
+                  "line": 91,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "localize",
+              "type": "Function",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 93,
+                  "column": 12
+                },
+                "end": {
+                  "line": 93,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 106,
+                  "column": 4
+                },
+                "end": {
+                  "line": 126,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 129,
+                  "column": 4
+                },
+                "end": {
+                  "line": 143,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_prepareHeaderTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 177,
+                  "column": 4
+                },
+                "end": {
+                  "line": 179,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_prepareFooterTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 181,
+                  "column": 4
+                },
+                "end": {
+                  "line": 183,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_prepareBodyTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 185,
+                  "column": 4
+                },
+                "end": {
+                  "line": 187,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_prepareTemplatizer",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 189,
+                  "column": 4
+                },
+                "end": {
+                  "line": 200,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "instanceProps"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_stampBodyTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 202,
+                  "column": 4
+                },
+                "end": {
+                  "line": 220,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_stampHeaderTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 105,
+                  "column": 8
+                },
+                "end": {
+                  "line": 122,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "headerTemplate"
+                },
+                {
+                  "name": "headerCell"
+                }
+              ]
+            },
+            {
+              "name": "_stampFooterTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 233,
+                  "column": 4
+                },
+                "end": {
+                  "line": 242,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "footerTemplate"
+                },
+                {
+                  "name": "footerCell"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_selectFirstTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 244,
+                  "column": 4
+                },
+                "end": {
+                  "line": 248,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selector"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_findTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 250,
+                  "column": 4
+                },
+                "end": {
+                  "line": 259,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selector"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_flexGrowChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 261,
+                  "column": 4
+                },
+                "end": {
+                  "line": 267,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "flexGrow"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_orderChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 269,
+                  "column": 4
+                },
+                "end": {
+                  "line": 271,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "order"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_widthChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 273,
+                  "column": 4
+                },
+                "end": {
+                  "line": 279,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "width"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_frozenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 281,
+                  "column": 4
+                },
+                "end": {
+                  "line": 289,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "frozen"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_lastFrozenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 291,
+                  "column": 4
+                },
+                "end": {
+                  "line": 297,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "lastFrozen"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_toggleAttribute",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 299,
+                  "column": 4
+                },
+                "end": {
+                  "line": 305,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name"
+                },
+                {
+                  "name": "on"
+                },
+                {
+                  "name": "element"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_reorderStatusChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 307,
+                  "column": 4
+                },
+                "end": {
+                  "line": 309,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "reorderStatus"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_resizableChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 311,
+                  "column": 4
+                },
+                "end": {
+                  "line": 332,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "resizable"
+                },
+                {
+                  "name": "headerCell"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_hiddenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 334,
+                  "column": 4
+                },
+                "end": {
+                  "line": 345,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "hidden"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_updateI18n",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 8
+                },
+                "end": {
+                  "line": 130,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "localize"
+                },
+                {
+                  "name": "_headerCellContentWrapper"
+                }
+              ]
+            },
+            {
+              "name": "_typeChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 8
+                },
+                "end": {
+                  "line": 136,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "type"
+                }
+              ]
+            },
+            {
+              "name": "_mappedObjectChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 138,
+                  "column": 8
+                },
+                "end": {
+                  "line": 146,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "obj"
+                }
+              ]
+            },
+            {
+              "name": "_checkIfValueChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 148,
+                  "column": 8
+                },
+                "end": {
+                  "line": 153,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                },
+                {
+                  "name": "propertyName"
+                }
+              ]
+            },
+            {
+              "name": "_columnHiddenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 155,
+                  "column": 8
+                },
+                "end": {
+                  "line": 157,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "hidden"
+                }
+              ]
+            },
+            {
+              "name": "_columnFrozenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 161,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "frozen"
+                }
+              ]
+            },
+            {
+              "name": "_fireStatusChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 163,
+                  "column": 8
+                },
+                "end": {
+                  "line": 175,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "mappedObject"
+                },
+                {
+                  "name": "value"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 27,
+              "column": 6
+            },
+            "end": {
+              "line": 176,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "Vaadin.GridColumnElement",
+          "name": "Predix.DataGridColumnElement",
+          "attributes": [
+            {
+              "name": "resizable",
+              "description": "When set to true, the column is user-resizable.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 24,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "frozen",
+              "description": "When true, the column is frozen. When a column inside of a column group is frozen,\nall of the sibling columns inside the group will get frozen also.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 61,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "hidden",
+              "description": "When set to true, the cells for this column are hidden.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 66,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "width",
+              "description": "Width of the cells for this column.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 382,
+                  "column": 10
+                },
+                "end": {
+                  "line": 385,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "flex-grow",
+              "description": "Flex grow ratio for the cell widths. When set to 0, cell width is fixed.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 390,
+                  "column": 10
+                },
+                "end": {
+                  "line": 393,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "number",
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "name",
+              "description": "Name of column is used on table action menu to offer hide/show functionality. As headers are fully optional\nand might not even contain the name of column, this separate value is required if you use table action menu.",
+              "sourceRange": {
+                "start": {
+                  "line": 39,
+                  "column": 12
+                },
+                "end": {
+                  "line": 41,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "path",
+              "description": "Path of column is used for the 'Group by column' functionality.",
+              "sourceRange": {
+                "start": {
+                  "line": 46,
+                  "column": 12
+                },
+                "end": {
+                  "line": 48,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "mapped-object",
+              "description": "Just a trick to map generated column instance to matching data object.\nCan be also used to update object when properties change.",
+              "sourceRange": {
+                "start": {
+                  "line": 54,
+                  "column": 12
+                },
+                "end": {
+                  "line": 57,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "type",
+              "description": "Type of the column. Can be string, number or date.",
+              "sourceRange": {
+                "start": {
+                  "line": 66,
+                  "column": 12
+                },
+                "end": {
+                  "line": 70,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "is-data-column",
+              "description": "Just to help to identify columns with data",
+              "sourceRange": {
+                "start": {
+                  "line": 80,
+                  "column": 12
+                },
+                "end": {
+                  "line": 83,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "is-remote-data-provider",
+              "description": "If true, the grid is in the remote-data-provider mode",
+              "sourceRange": {
+                "start": {
+                  "line": 88,
+                  "column": 12
+                },
+                "end": {
+                  "line": 91,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "localize",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 93,
+                  "column": 12
+                },
+                "end": {
+                  "line": 93,
+                  "column": 30
+                }
+              },
+              "metadata": {},
+              "type": "Function"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-data-grid-column"
+        },
+        {
+          "description": "Auto filtering field used by px-data-grid",
+          "summary": "",
+          "path": "px-auto-filter-field.html",
+          "properties": [
+            {
+              "name": "__dataClientsReady",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1139,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1139,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPendingClients",
+              "type": "Array",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1141,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1141,
+                  "column": 34
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataToNotify",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1143,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1143,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataLinkedPaths",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1145,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1145,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHasPaths",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1147,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1147,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataCompoundStorage",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1149,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1149,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHost",
+              "type": "Polymer_PropertyEffects",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1151,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1151,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataTemp",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1153,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1153,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataClientsInitialized",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1155,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1155,
+                  "column": 38
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__data",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1157,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1157,
+                  "column": 20
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPending",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1159,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataOld",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1161,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1161,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__computeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1163,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1163,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__reflectEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1165,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1165,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__notifyEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1167,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1167,
+                  "column": 29
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__propagateEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1169,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1169,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__observeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1171,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1171,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__readOnly",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1173,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1173,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__templateInfo",
+              "type": "!TemplateInfo",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1175,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1175,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_template",
+              "type": "HTMLTemplateElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 424,
+                  "column": 8
+                },
+                "end": {
+                  "line": 424,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 426,
+                  "column": 8
+                },
+                "end": {
+                  "line": 426,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "rootPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 428,
+                  "column": 8
+                },
+                "end": {
+                  "line": 428,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 430,
+                  "column": 8
+                },
+                "end": {
+                  "line": 430,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "root",
+              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 432,
+                  "column": 8
+                },
+                "end": {
+                  "line": 432,
+                  "column": 18
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "$",
+              "type": "!Object.<string, !Element>",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 434,
+                  "column": 8
+                },
+                "end": {
+                  "line": 434,
+                  "column": 15
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "placeholder",
+              "type": "string",
+              "description": "Placeholder text shown in field",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 12
+                },
+                "end": {
+                  "line": 42,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "timeout",
+              "type": "number",
+              "description": "Timeout value in milliseconds",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 47,
+                  "column": 12
+                },
+                "end": {
+                  "line": 50,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "400"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 52,
+                  "column": 12
+                },
+                "end": {
+                  "line": 56,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true,
+                  "observer": "\"_onChange\""
+                }
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "_stampTemplate",
+              "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2395,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2420,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to stamp"
+                }
+              ],
+              "return": {
+                "type": "!StampedTemplate",
+                "desc": "Cloned template content"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addMethodEventListenerToNode",
+              "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 452,
+                  "column": 6
+                },
+                "end": {
+                  "line": 457,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add listener on"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "methodName",
+                  "type": "string",
+                  "description": "Name of method"
+                },
+                {
+                  "name": "context",
+                  "type": "*=",
+                  "description": "Context the method will be called on (defaults\n  to `node`)"
+                }
+              ],
+              "return": {
+                "type": "Function",
+                "desc": "Generated handler function"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 467,
+                  "column": 6
+                },
+                "end": {
+                  "line": 469,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add event listener to"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to add"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 479,
+                  "column": 6
+                },
+                "end": {
+                  "line": 481,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to remove event listener from"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_createPropertyAccessor",
+              "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 105,
+                  "column": 8
+                },
+                "end": {
+                  "line": 118,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_definePropertyAccessor",
+              "description": "Defines a property accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 126,
+                  "column": 9
+                },
+                "end": {
+                  "line": 139,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "ready",
+              "description": "Stamps the element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 543,
+                  "column": 6
+                },
+                "end": {
+                  "line": 549,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeProperties",
+              "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 449,
+                  "column": 6
+                },
+                "end": {
+                  "line": 483,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeInstanceProperties",
+              "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 208,
+                  "column": 8
+                },
+                "end": {
+                  "line": 210,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of property values that were overwritten\n  when creating property accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setProperty",
+              "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 221,
+                  "column": 8
+                },
+                "end": {
+                  "line": 225,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_getProperty",
+              "description": "Returns the value for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 233,
+                  "column": 8
+                },
+                "end": {
+                  "line": 235,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value for the given property"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setPendingProperty",
+              "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 250,
+                  "column": 8
+                },
+                "end": {
+                  "line": 266,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "ext",
+                  "type": "boolean=",
+                  "description": "Not used here; affordance for closure"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property changed"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_invalidateProperties",
+              "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 276,
+                  "column": 8
+                },
+                "end": {
+                  "line": 286,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_enableProperties",
+              "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 299,
+                  "column": 8
+                },
+                "end": {
+                  "line": 308,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_flushProperties",
+              "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 319,
+                  "column": 8
+                },
+                "end": {
+                  "line": 325,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 339,
+                  "column": 8
+                },
+                "end": {
+                  "line": 340,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_shouldPropertyChange",
+              "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 360,
+                  "column": 8
+                },
+                "end": {
+                  "line": 367,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "New property value"
+                },
+                {
+                  "name": "old",
+                  "type": "*",
+                  "description": "Previous property value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeChangedCallback",
+              "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 379,
+                  "column": 8
+                },
+                "end": {
+                  "line": 386,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of attribute that changed"
+                },
+                {
+                  "name": "old",
+                  "type": "?string",
+                  "description": "Old attribute value"
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "New attribute value"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_attributeToProperty",
+              "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 400,
+                  "column": 8
+                },
+                "end": {
+                  "line": 407,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to deserialize."
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "of the attribute."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertyToAttribute",
+              "description": "Serializes a property to its associated attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 419,
+                  "column": 8
+                },
+                "end": {
+                  "line": 425,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name to reflect."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string=",
+                  "description": "Attribute name to reflect to."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Property value to refect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_valueToNodeAttribute",
+              "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 440,
+                  "column": 8
+                },
+                "end": {
+                  "line": 447,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Element to set attribute to."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to serialize."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Attribute name to serialize to."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_serializeValue",
+              "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 460,
+                  "column": 8
+                },
+                "end": {
+                  "line": 467,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Property value to serialize."
+                }
+              ],
+              "return": {
+                "type": "(string|undefined)",
+                "desc": "String serialized from the provided\nproperty  value."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_deserializeValue",
+              "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 481,
+                  "column": 8
+                },
+                "end": {
+                  "line": 490,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "Value to deserialize."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "Type to deserialize the string to."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Typed value deserialized from the provided string."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_initializeProtoProperties",
+              "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Properties to initialize on the prototype"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_ensureAttribute",
+              "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 186,
+                  "column": 6
+                },
+                "end": {
+                  "line": 191,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to ensure is set."
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "of the attribute."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_hasAccessor",
+              "description": "Returns true if this library created an accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 293,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if an accessor was created"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_isPropertyPending",
+              "description": "Returns true if the specified property has a pending change.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 304,
+                  "column": 6
+                },
+                "end": {
+                  "line": 306,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if property has a pending change"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_addPropertyEffect",
+              "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1247,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1255,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removePropertyEffect",
+              "description": "Removes the given property effect.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1265,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1271,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property the effect was associated with"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasPropertyEffect",
+              "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1282,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1285,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "type",
+                  "type": "string=",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReadOnlyEffect",
+              "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1295,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1297,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasNotifyEffect",
+              "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1307,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1309,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReflectEffect",
+              "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1319,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1321,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasComputedEffect",
+              "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1331,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1333,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setPendingPropertyOrPath",
+              "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1365,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1397,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(number|string)>)",
+                  "description": "Path to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "shouldNotify",
+                  "type": "boolean=",
+                  "description": "Set to true if this change should\n cause a property notification event dispatch"
+                },
+                {
+                  "name": "isPathNotification",
+                  "type": "boolean=",
+                  "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setUnmanagedPropertyToNode",
+              "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1420,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1428,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "The node to set a property on"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "The property to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "The value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_enqueueClient",
+              "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1535,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1540,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "client",
+                  "type": "Object",
+                  "description": "PropertyEffects client to enqueue"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_flushClients",
+              "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1572,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__enableOrFlushClients",
+              "description": "(c) the stamped dom enables.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1586,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1599,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_readyClients",
+              "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 570,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "setProperties",
+              "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1628,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1639,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+                },
+                {
+                  "name": "setReadOnly",
+                  "type": "boolean=",
+                  "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_propagatePropertyChanges",
+              "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1726,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1736,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "changedProps",
+                  "type": "Object",
+                  "description": "Bag of changed properties"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "linkPaths",
+              "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1747,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1752,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "to",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to link."
+                },
+                {
+                  "name": "from",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Source path to link."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unlinkPaths",
+              "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1764,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1769,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to unlink."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifySplices",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1801,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1805,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "splices",
+                  "type": "Array",
+                  "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "get",
+              "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1826,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1828,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "set",
+              "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1851,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1861,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set at the specified path."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "push",
+              "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1877,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1886,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to push onto array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "pop",
+              "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1901,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1910,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "splice",
+              "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1929,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1946,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "start",
+                  "type": "number",
+                  "description": "Index from which to start removing/inserting."
+                },
+                {
+                  "name": "deleteCount",
+                  "type": "number",
+                  "description": "Number of items to remove."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert into array."
+                }
+              ],
+              "return": {
+                "type": "Array",
+                "desc": "Array of removed items."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "shift",
+              "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1961,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1970,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unshift",
+              "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1986,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1994,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert info array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifyPath",
+              "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2009,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2026,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Value at the path (optional)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReadOnlyProperty",
+              "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2039,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2046,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createPropertyObserver",
+              "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2060,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2070,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createMethodObserver",
+              "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2083,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2089,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createNotifyingProperty",
+              "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2100,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2108,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReflectedProperty",
+              "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2119,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2132,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createComputedProperty",
+              "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2146,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2152,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_bindTemplate",
+              "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2329,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2352,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                },
+                {
+                  "name": "instanceBinding",
+                  "type": "boolean=",
+                  "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removeBoundDom",
+              "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2431,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2452,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "!StampedTemplate",
+                  "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "connectedCallback",
+              "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 530,
+                  "column": 6
+                },
+                "end": {
+                  "line": 535,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "Called when the element is removed from a document",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_attachDom",
+              "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 584,
+                  "column": 6
+                },
+                "end": {
+                  "line": 600,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "StampedTemplate",
+                  "description": "to attach to the element."
+                }
+              ],
+              "return": {
+                "type": "ShadowRoot",
+                "desc": "node to which the dom has been attached."
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "updateStyles",
+              "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 620,
+                  "column": 6
+                },
+                "end": {
+                  "line": 624,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "properties",
+                  "type": "Object=",
+                  "description": "Bag of custom property key/values to\n  apply to this element."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "resolveUrl",
+              "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 637,
+                  "column": 6
+                },
+                "end": {
+                  "line": 642,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "url",
+                  "type": "string",
+                  "description": "URL to resolve."
+                },
+                {
+                  "name": "base",
+                  "type": "string=",
+                  "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Rewritten URL relative to base"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_onChange",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 60,
+                  "column": 8
+                },
+                "end": {
+                  "line": 71,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "_parseTemplate",
+              "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 197,
+                  "column": 6
+                },
+                "end": {
+                  "line": 208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to parse"
+                },
+                {
+                  "name": "outerTemplateInfo",
+                  "type": "TemplateInfo=",
+                  "description": "Template metadata from the outer\n  template, for parsing nested templates"
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Parsed template metadata"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateContent",
+              "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 653,
+                  "column": 6
+                },
+                "end": {
+                  "line": 656,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "templateInfo"
+                },
+                {
+                  "name": "nodeInfo"
+                }
+              ],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_parseTemplateNode",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2471,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2485,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateChildNodes",
+              "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 258,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "root",
+                  "type": "Node",
+                  "description": "Root node whose `childNodes` will be parsed"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "!TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "!NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNestedTemplate",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2558,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2568,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateNodeAttributes",
+              "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 333,
+                  "column": 6
+                },
+                "end": {
+                  "line": 342,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNodeAttribute",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2542,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_contentForTemplate",
+              "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 388,
+                  "column": 6
+                },
+                "end": {
+                  "line": 391,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template to retrieve `content` for"
+                }
+              ],
+              "return": {
+                "type": "DocumentFragment",
+                "desc": "Content fragment"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "createProperties",
+              "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 328,
+                  "column": 7
+                },
+                "end": {
+                  "line": 332,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "attributeNameForProperty",
+              "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 76,
+                  "column": 8
+                },
+                "end": {
+                  "line": 78,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property to convert"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Attribute name corresponding to the given property."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "typeForProperty",
+              "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 174,
+                  "column": 6
+                },
+                "end": {
+                  "line": 177,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Type to which to deserialize attribute"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "createPropertiesForAttributes",
+              "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 127,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "addPropertyEffect",
+              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2192,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2194,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createPropertyObserver",
+              "description": "Creates a single-property observer for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2206,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createMethodObserver",
+              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2223,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2225,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating"
+                }
+              ],
+              "return": {
+                "type": "void",
+                "desc": "whether method names should be included as a dependency to the effect."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createNotifyingProperty",
+              "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2235,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2237,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReadOnlyProperty",
+              "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2255,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2257,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReflectedProperty",
+              "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2267,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2269,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createComputedProperty",
+              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2285,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2287,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "bindTemplate",
+              "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2301,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2303,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Template metadata object"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addTemplatePropertyEffect",
+              "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2367,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2373,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Template metadata to add effect to"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseBindings",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2603,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2668,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "description": "Text to parse from attribute or textContent"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Current template metadata"
+                }
+              ],
+              "return": {
+                "type": "Array.<!BindingPart>",
+                "desc": "Array of binding part metadata"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_evaluateBinding",
+              "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2684,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2701,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "inst",
+                  "type": "this",
+                  "description": "Element that should be used as scope for\n  binding dependencies"
+                },
+                {
+                  "name": "part",
+                  "type": "BindingPart",
+                  "description": "Binding part metadata"
+                },
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Property/path that triggered this effect"
+                },
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of current property changes"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value the binding part evaluated to"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "finalize",
+              "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 131,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_finalizeClass",
+              "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 296,
+                  "column": 5
+                },
+                "end": {
+                  "line": 319,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "createObservers",
+              "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 345,
+                  "column": 6
+                },
+                "end": {
+                  "line": 350,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "observers",
+                  "type": "Object",
+                  "description": "Array of observer descriptors for\n  this class"
+                },
+                {
+                  "name": "dynamicFns",
+                  "type": "Object",
+                  "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for a style element in the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 493,
+                  "column": 6
+                },
+                "end": {
+                  "line": 495,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "cssText",
+                  "type": "string",
+                  "description": "Text containing styling to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The processed CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 517,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            }
+          ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 29,
+              "column": 6
+            },
+            "end": {
+              "line": 72,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "Polymer.Element",
+          "name": "Predix.AutoFilterFieldElement",
+          "attributes": [
+            {
+              "name": "placeholder",
+              "description": "Placeholder text shown in field",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 12
+                },
+                "end": {
+                  "line": 42,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "timeout",
+              "description": "Timeout value in milliseconds",
+              "sourceRange": {
+                "start": {
+                  "line": 47,
+                  "column": 12
+                },
+                "end": {
+                  "line": 50,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "value",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 52,
+                  "column": 12
+                },
+                "end": {
+                  "line": 56,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            }
+          ],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "value-changed",
+              "description": "Fired when the `value` property changes.",
+              "metadata": {}
+            }
+          ],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-auto-filter-field"
+        },
+        {
+          "description": "Navigation component that is the UI component for paging.\n\n#### Example:\n```html\n<px-data-grid-navigation\n  on-navigation-change=\"_onNavigationChange\"\n  selectable-page-sizes=\"[10, 20, 30]\"\n  page-size=\"10\"\n  total-item-count=\"300\"\n  current-page=\"1\"\n  number-of-pages=\"50\">\n</px-data-grid-navigation>\n```",
+          "summary": "",
+          "path": "px-data-grid-navigation.html",
+          "properties": [
+            {
+              "name": "__dataClientsReady",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1139,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1139,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPendingClients",
+              "type": "Array",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1141,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1141,
+                  "column": 34
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataToNotify",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1143,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1143,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataLinkedPaths",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1145,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1145,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHasPaths",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1147,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1147,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataCompoundStorage",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1149,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1149,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHost",
+              "type": "Polymer_PropertyEffects",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1151,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1151,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataTemp",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1153,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1153,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataClientsInitialized",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1155,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1155,
+                  "column": 38
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__data",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1157,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1157,
+                  "column": 20
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPending",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1159,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataOld",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1161,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1161,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__computeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1163,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1163,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__reflectEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1165,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1165,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__notifyEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1167,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1167,
+                  "column": 29
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__propagateEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1169,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1169,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__observeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1171,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1171,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__readOnly",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1173,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1173,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__templateInfo",
+              "type": "!TemplateInfo",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1175,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1175,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_template",
+              "type": "HTMLTemplateElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 424,
+                  "column": 8
+                },
+                "end": {
+                  "line": 424,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 426,
+                  "column": 8
+                },
+                "end": {
+                  "line": 426,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "rootPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 428,
+                  "column": 8
+                },
+                "end": {
+                  "line": 428,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 430,
+                  "column": 8
+                },
+                "end": {
+                  "line": 430,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "root",
+              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 432,
+                  "column": 8
+                },
+                "end": {
+                  "line": 432,
+                  "column": 18
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "$",
+              "type": "!Object.<string, !Element>",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 434,
+                  "column": 8
+                },
+                "end": {
+                  "line": 434,
+                  "column": 15
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "selectablePageSizes",
+              "type": "Array",
+              "description": "Values selectable by user that dicatate how many items to show per page.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 96,
+                  "column": 12
+                },
+                "end": {
+                  "line": 103,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "[10,20,30]"
+            },
+            {
+              "name": "pageSize",
+              "type": "number",
+              "description": "Current number of items/rows per page.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 108,
+                  "column": 12
+                },
+                "end": {
+                  "line": 111,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "10"
+            },
+            {
+              "name": "currentPage",
+              "type": "number",
+              "description": "Currently displayed page number.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 116,
+                  "column": 12
+                },
+                "end": {
+                  "line": 119,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "0"
+            },
+            {
+              "name": "numberOfPages",
+              "type": "number",
+              "description": "Total number of pages.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 12
+                },
+                "end": {
+                  "line": 127,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "0"
+            },
+            {
+              "name": "totalItemCount",
+              "type": "number",
+              "description": "Total number of items in table.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 12
+                },
+                "end": {
+                  "line": 135,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "0"
+            },
+            {
+              "name": "hidePageList",
+              "type": "boolean",
+              "description": "If true, the page numbers list is not shown.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 140,
+                  "column": 12
+                },
+                "end": {
+                  "line": 143,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "_pageListMaxCount",
+              "type": "number",
+              "description": "Max number of page number items to show in the page list.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 148,
+                  "column": 12
+                },
+                "end": {
+                  "line": 151,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "9"
+            }
+          ],
+          "methods": [
+            {
+              "name": "_stampTemplate",
+              "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2395,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2420,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to stamp"
+                }
+              ],
+              "return": {
+                "type": "!StampedTemplate",
+                "desc": "Cloned template content"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addMethodEventListenerToNode",
+              "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 452,
+                  "column": 6
+                },
+                "end": {
+                  "line": 457,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add listener on"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "methodName",
+                  "type": "string",
+                  "description": "Name of method"
+                },
+                {
+                  "name": "context",
+                  "type": "*=",
+                  "description": "Context the method will be called on (defaults\n  to `node`)"
+                }
+              ],
+              "return": {
+                "type": "Function",
+                "desc": "Generated handler function"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 467,
+                  "column": 6
+                },
+                "end": {
+                  "line": 469,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add event listener to"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to add"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 479,
+                  "column": 6
+                },
+                "end": {
+                  "line": 481,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to remove event listener from"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_createPropertyAccessor",
+              "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 105,
+                  "column": 8
+                },
+                "end": {
+                  "line": 118,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_definePropertyAccessor",
+              "description": "Defines a property accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 126,
+                  "column": 9
+                },
+                "end": {
+                  "line": 139,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "ready",
+              "description": "Stamps the element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 543,
+                  "column": 6
+                },
+                "end": {
+                  "line": 549,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeProperties",
+              "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 449,
+                  "column": 6
+                },
+                "end": {
+                  "line": 483,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeInstanceProperties",
+              "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 208,
+                  "column": 8
+                },
+                "end": {
+                  "line": 210,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of property values that were overwritten\n  when creating property accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setProperty",
+              "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 221,
+                  "column": 8
+                },
+                "end": {
+                  "line": 225,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_getProperty",
+              "description": "Returns the value for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 233,
+                  "column": 8
+                },
+                "end": {
+                  "line": 235,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value for the given property"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setPendingProperty",
+              "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 250,
+                  "column": 8
+                },
+                "end": {
+                  "line": 266,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "ext",
+                  "type": "boolean=",
+                  "description": "Not used here; affordance for closure"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property changed"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_invalidateProperties",
+              "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 276,
+                  "column": 8
+                },
+                "end": {
+                  "line": 286,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_enableProperties",
+              "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 299,
+                  "column": 8
+                },
+                "end": {
+                  "line": 308,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_flushProperties",
+              "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 319,
+                  "column": 8
+                },
+                "end": {
+                  "line": 325,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 339,
+                  "column": 8
+                },
+                "end": {
+                  "line": 340,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_shouldPropertyChange",
+              "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 360,
+                  "column": 8
+                },
+                "end": {
+                  "line": 367,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "New property value"
+                },
+                {
+                  "name": "old",
+                  "type": "*",
+                  "description": "Previous property value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeChangedCallback",
+              "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 379,
+                  "column": 8
+                },
+                "end": {
+                  "line": 386,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of attribute that changed"
+                },
+                {
+                  "name": "old",
+                  "type": "?string",
+                  "description": "Old attribute value"
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "New attribute value"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_attributeToProperty",
+              "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 400,
+                  "column": 8
+                },
+                "end": {
+                  "line": 407,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to deserialize."
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "of the attribute."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertyToAttribute",
+              "description": "Serializes a property to its associated attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 419,
+                  "column": 8
+                },
+                "end": {
+                  "line": 425,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name to reflect."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string=",
+                  "description": "Attribute name to reflect to."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Property value to refect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_valueToNodeAttribute",
+              "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 440,
+                  "column": 8
+                },
+                "end": {
+                  "line": 447,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Element to set attribute to."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to serialize."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Attribute name to serialize to."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_serializeValue",
+              "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 460,
+                  "column": 8
+                },
+                "end": {
+                  "line": 467,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Property value to serialize."
+                }
+              ],
+              "return": {
+                "type": "(string|undefined)",
+                "desc": "String serialized from the provided\nproperty  value."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_deserializeValue",
+              "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 481,
+                  "column": 8
+                },
+                "end": {
+                  "line": 490,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "Value to deserialize."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "Type to deserialize the string to."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Typed value deserialized from the provided string."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_initializeProtoProperties",
+              "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Properties to initialize on the prototype"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_ensureAttribute",
+              "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 186,
+                  "column": 6
+                },
+                "end": {
+                  "line": 191,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to ensure is set."
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "of the attribute."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_hasAccessor",
+              "description": "Returns true if this library created an accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 293,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if an accessor was created"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_isPropertyPending",
+              "description": "Returns true if the specified property has a pending change.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 304,
+                  "column": 6
+                },
+                "end": {
+                  "line": 306,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if property has a pending change"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_addPropertyEffect",
+              "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1247,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1255,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removePropertyEffect",
+              "description": "Removes the given property effect.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1265,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1271,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property the effect was associated with"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasPropertyEffect",
+              "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1282,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1285,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "type",
+                  "type": "string=",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReadOnlyEffect",
+              "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1295,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1297,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasNotifyEffect",
+              "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1307,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1309,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReflectEffect",
+              "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1319,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1321,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasComputedEffect",
+              "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1331,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1333,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setPendingPropertyOrPath",
+              "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1365,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1397,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(number|string)>)",
+                  "description": "Path to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "shouldNotify",
+                  "type": "boolean=",
+                  "description": "Set to true if this change should\n cause a property notification event dispatch"
+                },
+                {
+                  "name": "isPathNotification",
+                  "type": "boolean=",
+                  "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setUnmanagedPropertyToNode",
+              "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1420,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1428,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "The node to set a property on"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "The property to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "The value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_enqueueClient",
+              "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1535,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1540,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "client",
+                  "type": "Object",
+                  "description": "PropertyEffects client to enqueue"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_flushClients",
+              "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1572,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__enableOrFlushClients",
+              "description": "(c) the stamped dom enables.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1586,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1599,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_readyClients",
+              "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 570,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "setProperties",
+              "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1628,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1639,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+                },
+                {
+                  "name": "setReadOnly",
+                  "type": "boolean=",
+                  "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_propagatePropertyChanges",
+              "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1726,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1736,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "changedProps",
+                  "type": "Object",
+                  "description": "Bag of changed properties"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "linkPaths",
+              "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1747,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1752,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "to",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to link."
+                },
+                {
+                  "name": "from",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Source path to link."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unlinkPaths",
+              "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1764,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1769,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to unlink."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifySplices",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1801,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1805,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "splices",
+                  "type": "Array",
+                  "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "get",
+              "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1826,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1828,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "set",
+              "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1851,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1861,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set at the specified path."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "push",
+              "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1877,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1886,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to push onto array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "pop",
+              "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1901,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1910,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "splice",
+              "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1929,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1946,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "start",
+                  "type": "number",
+                  "description": "Index from which to start removing/inserting."
+                },
+                {
+                  "name": "deleteCount",
+                  "type": "number",
+                  "description": "Number of items to remove."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert into array."
+                }
+              ],
+              "return": {
+                "type": "Array",
+                "desc": "Array of removed items."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "shift",
+              "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1961,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1970,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unshift",
+              "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1986,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1994,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert info array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifyPath",
+              "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2009,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2026,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Value at the path (optional)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReadOnlyProperty",
+              "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2039,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2046,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createPropertyObserver",
+              "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2060,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2070,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createMethodObserver",
+              "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2083,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2089,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createNotifyingProperty",
+              "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2100,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2108,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReflectedProperty",
+              "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2119,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2132,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createComputedProperty",
+              "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2146,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2152,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_bindTemplate",
+              "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2329,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2352,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                },
+                {
+                  "name": "instanceBinding",
+                  "type": "boolean=",
+                  "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removeBoundDom",
+              "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2431,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2452,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "!StampedTemplate",
+                  "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "connectedCallback",
+              "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 530,
+                  "column": 6
+                },
+                "end": {
+                  "line": 535,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "Called when the element is removed from a document",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_attachDom",
+              "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 584,
+                  "column": 6
+                },
+                "end": {
+                  "line": 600,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "StampedTemplate",
+                  "description": "to attach to the element."
+                }
+              ],
+              "return": {
+                "type": "ShadowRoot",
+                "desc": "node to which the dom has been attached."
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "updateStyles",
+              "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 620,
+                  "column": 6
+                },
+                "end": {
+                  "line": 624,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "properties",
+                  "type": "Object=",
+                  "description": "Bag of custom property key/values to\n  apply to this element."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "resolveUrl",
+              "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 637,
+                  "column": 6
+                },
+                "end": {
+                  "line": 642,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "url",
+                  "type": "string",
+                  "description": "URL to resolve."
+                },
+                {
+                  "name": "base",
+                  "type": "string=",
+                  "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Rewritten URL relative to base"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_pageSizeChange",
+              "description": "Fired when user selects a new page size.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 171,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_onPageClick",
+              "description": "Fired when user clicks on a page number.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 176,
+                  "column": 8
+                },
+                "end": {
+                  "line": 184,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_onBackClick",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 186,
+                  "column": 8
+                },
+                "end": {
+                  "line": 194,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_onNextClick",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 196,
+                  "column": 8
+                },
+                "end": {
+                  "line": 204,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_fireChangeEvent",
+              "description": "Fires the general change event which includes all data\nthat can be set by the user.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 210,
+                  "column": 8
+                },
+                "end": {
+                  "line": 215,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "detail"
+                }
+              ]
+            },
+            {
+              "name": "_numArrayToStrArray",
+              "description": "Converts array of Numbers to array of Strings.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 220,
+                  "column": 8
+                },
+                "end": {
+                  "line": 224,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "numArray"
+                }
+              ]
+            },
+            {
+              "name": "_numToStr",
+              "description": "Converts a Number to a String.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 229,
+                  "column": 8
+                },
+                "end": {
+                  "line": 231,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "num"
+                }
+              ]
+            },
+            {
+              "name": "_getItemsRangeStr",
+              "description": "Returns string showing the min and max item numbers based on\nthe current page.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 237,
+                  "column": 8
+                },
+                "end": {
+                  "line": 245,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentPage"
+                },
+                {
+                  "name": "pageSize"
+                },
+                {
+                  "name": "totalItemCount"
+                }
+              ]
+            },
+            {
+              "name": "_getOfStr",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 247,
+                  "column": 8
+                },
+                "end": {
+                  "line": 249,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "totalItemCount"
+                }
+              ]
+            },
+            {
+              "name": "_getPagesList",
+              "description": "Gets an array of page numbers based on the numberOfPages property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 254,
+                  "column": 8
+                },
+                "end": {
+                  "line": 296,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_isCurrentPage",
+              "description": "Returns true if param pageNumber is equal to this.currentPage.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 301,
+                  "column": 8
+                },
+                "end": {
+                  "line": 303,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "pageNumber"
+                }
+              ]
+            },
+            {
+              "name": "_isBackArrowEnabled",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 305,
+                  "column": 8
+                },
+                "end": {
+                  "line": 307,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentPage"
+                }
+              ]
+            },
+            {
+              "name": "_isNextArrowEnabled",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 309,
+                  "column": 8
+                },
+                "end": {
+                  "line": 311,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentPage"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "_parseTemplate",
+              "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 197,
+                  "column": 6
+                },
+                "end": {
+                  "line": 208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to parse"
+                },
+                {
+                  "name": "outerTemplateInfo",
+                  "type": "TemplateInfo=",
+                  "description": "Template metadata from the outer\n  template, for parsing nested templates"
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Parsed template metadata"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateContent",
+              "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 653,
+                  "column": 6
+                },
+                "end": {
+                  "line": 656,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "templateInfo"
+                },
+                {
+                  "name": "nodeInfo"
+                }
+              ],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_parseTemplateNode",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2471,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2485,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateChildNodes",
+              "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 258,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "root",
+                  "type": "Node",
+                  "description": "Root node whose `childNodes` will be parsed"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "!TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "!NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNestedTemplate",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2558,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2568,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateNodeAttributes",
+              "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 333,
+                  "column": 6
+                },
+                "end": {
+                  "line": 342,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNodeAttribute",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2542,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_contentForTemplate",
+              "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 388,
+                  "column": 6
+                },
+                "end": {
+                  "line": 391,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template to retrieve `content` for"
+                }
+              ],
+              "return": {
+                "type": "DocumentFragment",
+                "desc": "Content fragment"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "createProperties",
+              "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 328,
+                  "column": 7
+                },
+                "end": {
+                  "line": 332,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "attributeNameForProperty",
+              "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 76,
+                  "column": 8
+                },
+                "end": {
+                  "line": 78,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property to convert"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Attribute name corresponding to the given property."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "typeForProperty",
+              "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 174,
+                  "column": 6
+                },
+                "end": {
+                  "line": 177,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Type to which to deserialize attribute"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "createPropertiesForAttributes",
+              "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 127,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "addPropertyEffect",
+              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2192,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2194,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createPropertyObserver",
+              "description": "Creates a single-property observer for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2206,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createMethodObserver",
+              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2223,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2225,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating"
+                }
+              ],
+              "return": {
+                "type": "void",
+                "desc": "whether method names should be included as a dependency to the effect."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createNotifyingProperty",
+              "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2235,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2237,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReadOnlyProperty",
+              "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2255,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2257,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReflectedProperty",
+              "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2267,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2269,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createComputedProperty",
+              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2285,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2287,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "bindTemplate",
+              "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2301,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2303,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Template metadata object"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addTemplatePropertyEffect",
+              "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2367,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2373,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Template metadata to add effect to"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseBindings",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2603,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2668,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "description": "Text to parse from attribute or textContent"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Current template metadata"
+                }
+              ],
+              "return": {
+                "type": "Array.<!BindingPart>",
+                "desc": "Array of binding part metadata"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_evaluateBinding",
+              "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2684,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2701,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "inst",
+                  "type": "this",
+                  "description": "Element that should be used as scope for\n  binding dependencies"
+                },
+                {
+                  "name": "part",
+                  "type": "BindingPart",
+                  "description": "Binding part metadata"
+                },
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Property/path that triggered this effect"
+                },
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of current property changes"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value the binding part evaluated to"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "finalize",
+              "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 131,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_finalizeClass",
+              "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 296,
+                  "column": 5
+                },
+                "end": {
+                  "line": 319,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "createObservers",
+              "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 345,
+                  "column": 6
+                },
+                "end": {
+                  "line": 350,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "observers",
+                  "type": "Object",
+                  "description": "Array of observer descriptors for\n  this class"
+                },
+                {
+                  "name": "dynamicFns",
+                  "type": "Object",
+                  "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for a style element in the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 493,
+                  "column": 6
+                },
+                "end": {
+                  "line": 495,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "cssText",
+                  "type": "string",
+                  "description": "Text containing styling to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The processed CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 517,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            }
+          ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 85,
+              "column": 6
+            },
+            "end": {
+              "line": 313,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "Polymer.Element",
+          "name": "Predix.DataGridNavigationElement",
+          "attributes": [
+            {
+              "name": "selectable-page-sizes",
+              "description": "Values selectable by user that dicatate how many items to show per page.",
+              "sourceRange": {
+                "start": {
+                  "line": 96,
+                  "column": 12
+                },
+                "end": {
+                  "line": 103,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "Array"
+            },
+            {
+              "name": "page-size",
+              "description": "Current number of items/rows per page.",
+              "sourceRange": {
+                "start": {
+                  "line": 108,
+                  "column": 12
+                },
+                "end": {
+                  "line": 111,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "current-page",
+              "description": "Currently displayed page number.",
+              "sourceRange": {
+                "start": {
+                  "line": 116,
+                  "column": 12
+                },
+                "end": {
+                  "line": 119,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "number-of-pages",
+              "description": "Total number of pages.",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 12
+                },
+                "end": {
+                  "line": 127,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "total-item-count",
+              "description": "Total number of items in table.",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 12
+                },
+                "end": {
+                  "line": 135,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "hide-page-list",
+              "description": "If true, the page numbers list is not shown.",
+              "sourceRange": {
+                "start": {
+                  "line": 140,
+                  "column": 12
+                },
+                "end": {
+                  "line": 143,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-data-grid-navigation"
+        },
+        {
+          "description": "`<px-data-grid-selection-column>` is a helper element for the `<px-data-grid>`\nto be used to offer selection column behavior with multi and single select.",
+          "summary": "",
+          "path": "px-data-grid-selection-column.html",
+          "properties": [
+            {
+              "name": "resizable",
+              "type": "boolean",
+              "description": "When set to true, the column is user-resizable.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 24,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "headerTemplate",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "start": {
+                  "line": 109,
+                  "column": 10
+                },
+                "end": {
+                  "line": 109,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "footerTemplate",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 50,
+                  "column": 8
+                },
+                "end": {
+                  "line": 52,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "frozen",
+              "type": "boolean",
+              "description": "When true, the column is frozen. When a column inside of a column group is frozen,\nall of the sibling columns inside the group will get frozen also.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 61,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "hidden",
+              "type": "boolean",
+              "description": "When set to true, the cells for this column are hidden.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 66,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_lastFrozen",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 70,
+                  "column": 8
+                },
+                "end": {
+                  "line": 73,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_order",
+              "type": "number",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 75,
+                  "column": 8
+                },
+                "end": {
+                  "line": 75,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_reorderStatus",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 77,
+                  "column": 8
+                },
+                "end": {
+                  "line": 77,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_emptyCells",
+              "type": "Array",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 79,
+                  "column": 8
+                },
+                "end": {
+                  "line": 79,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_headerCell",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 81,
+                  "column": 8
+                },
+                "end": {
+                  "line": 81,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_footerCell",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 83,
+                  "column": 8
+                },
+                "end": {
+                  "line": 83,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_grid",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 85,
+                  "column": 8
+                },
+                "end": {
+                  "line": 85,
+                  "column": 21
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "width",
+              "type": "string",
+              "description": "Width of the cells for this column.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 61,
+                  "column": 10
+                },
+                "end": {
+                  "line": 64,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "\"56px\""
+            },
+            {
+              "name": "flexGrow",
+              "type": "number",
+              "description": "Flex grow ratio for the cell widths. When set to 0, cell width is fixed.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 69,
+                  "column": 10
+                },
+                "end": {
+                  "line": 72,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "0"
+            },
+            {
+              "name": "template",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "start": {
+                  "line": 114,
+                  "column": 10
+                },
+                "end": {
+                  "line": 114,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_cells",
+              "type": "Array",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 402,
+                  "column": 10
+                },
+                "end": {
+                  "line": 402,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Vaadin.GridColumnElement"
+            },
+            {
+              "name": "selectAll",
+              "type": "boolean",
+              "description": "When true, all the items are selected.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 77,
+                  "column": 10
+                },
+                "end": {
+                  "line": 81,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "notify": true
+                }
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "autoSelect",
+              "type": "boolean",
+              "description": "When true, the active gets automatically selected.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 86,
+                  "column": 10
+                },
+                "end": {
+                  "line": 89,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "multiSelect",
+              "type": "boolean",
+              "description": "When true, user is allowed to multiselect",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 94,
+                  "column": 10
+                },
+                "end": {
+                  "line": 97,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "true"
+            },
+            {
+              "name": "treeGrid",
+              "type": "boolean",
+              "description": "When true, the grid is in tree-grid mode (group by column/value)",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 102,
+                  "column": 10
+                },
+                "end": {
+                  "line": 104,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_indeterminate",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 116,
+                  "column": 10
+                },
+                "end": {
+                  "line": 116,
+                  "column": 33
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_previousActiveItem",
+              "type": "Object",
+              "description": "The previous state of activeItem. When activeItem turns to `null`,\npreviousActiveItem will have an Object with just unselected activeItem",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 122,
+                  "column": 10
+                },
+                "end": {
+                  "line": 122,
+                  "column": 37
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_selectAllHidden",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 10
+                },
+                "end": {
+                  "line": 127,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "true"
+            },
+            {
+              "name": "isDataColumn",
+              "type": "boolean",
+              "description": "Just to help to identify columns without data",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 10
+                },
+                "end": {
+                  "line": 136,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": true
+                }
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "_selectionCount",
+              "type": "number",
+              "description": "Current selection count",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 141,
+                  "column": 10
+                },
+                "end": {
+                  "line": 144,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "0"
+            }
+          ],
+          "methods": [
+            {
+              "name": "connectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "start": {
+                  "line": 206,
+                  "column": 6
+                },
+                "end": {
+                  "line": 220,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "start": {
+                  "line": 179,
+                  "column": 6
+                },
+                "end": {
+                  "line": 203,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_prepareHeaderTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 154,
+                  "column": 6
+                },
+                "end": {
+                  "line": 160,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_prepareFooterTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 181,
+                  "column": 4
+                },
+                "end": {
+                  "line": 183,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_prepareBodyTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 162,
+                  "column": 6
+                },
+                "end": {
+                  "line": 168,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_prepareTemplatizer",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 189,
+                  "column": 4
+                },
+                "end": {
+                  "line": 200,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "instanceProps"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_stampBodyTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 202,
+                  "column": 4
+                },
+                "end": {
+                  "line": 220,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_stampHeaderTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 222,
+                  "column": 4
+                },
+                "end": {
+                  "line": 231,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "headerTemplate"
+                },
+                {
+                  "name": "headerCell"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_stampFooterTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 233,
+                  "column": 4
+                },
+                "end": {
+                  "line": 242,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "footerTemplate"
+                },
+                {
+                  "name": "footerCell"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_selectFirstTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 244,
+                  "column": 4
+                },
+                "end": {
+                  "line": 248,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selector"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_findTemplate",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 250,
+                  "column": 4
+                },
+                "end": {
+                  "line": 259,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selector"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_flexGrowChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 261,
+                  "column": 4
+                },
+                "end": {
+                  "line": 267,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "flexGrow"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_orderChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 269,
+                  "column": 4
+                },
+                "end": {
+                  "line": 271,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "order"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_widthChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 273,
+                  "column": 4
+                },
+                "end": {
+                  "line": 279,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "width"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_frozenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 281,
+                  "column": 4
+                },
+                "end": {
+                  "line": 289,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "frozen"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_lastFrozenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 291,
+                  "column": 4
+                },
+                "end": {
+                  "line": 297,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "lastFrozen"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_toggleAttribute",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 299,
+                  "column": 4
+                },
+                "end": {
+                  "line": 305,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name"
+                },
+                {
+                  "name": "on"
+                },
+                {
+                  "name": "element"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_reorderStatusChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 307,
+                  "column": 4
+                },
+                "end": {
+                  "line": 309,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "reorderStatus"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_resizableChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 311,
+                  "column": 4
+                },
+                "end": {
+                  "line": 332,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "resizable"
+                },
+                {
+                  "name": "headerCell"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_hiddenChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 334,
+                  "column": 4
+                },
+                "end": {
+                  "line": 345,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "hidden"
+                },
+                {
+                  "name": "headerCell"
+                },
+                {
+                  "name": "footerCell"
+                },
+                {
+                  "name": "cells"
+                }
+              ],
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "_isGroupItem",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 222,
+                  "column": 6
+                },
+                "end": {
+                  "line": 224,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "item"
+                }
+              ]
+            },
+            {
+              "name": "_onSelectAllChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 226,
+                  "column": 6
+                },
+                "end": {
+                  "line": 240,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selectAll"
+                }
+              ]
+            },
+            {
+              "name": "_arrayContains",
+              "description": "We need this when sorting or to preserve selection after filtering.",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 244,
+                  "column": 6
+                },
+                "end": {
+                  "line": 247,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "a"
+                },
+                {
+                  "name": "b"
+                }
+              ]
+            },
+            {
+              "name": "_onSelectAllCheckedChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 249,
+                  "column": 6
+                },
+                "end": {
+                  "line": 251,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_isChecked",
+              "description": "iOS needs indeterminated + checked at the same time",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 254,
+                  "column": 6
+                },
+                "end": {
+                  "line": 256,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "selectAll"
+                },
+                {
+                  "name": "indeterminate"
+                }
+              ]
+            },
+            {
+              "name": "_onActiveItemChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 258,
+                  "column": 6
+                },
+                "end": {
+                  "line": 267,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_onSelectedItemsChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 269,
+                  "column": 6
+                },
+                "end": {
+                  "line": 287,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            },
+            {
+              "name": "_onDataProviderChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 289,
+                  "column": 6
+                },
+                "end": {
+                  "line": 291,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "e"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 50,
+              "column": 4
+            },
+            "end": {
+              "line": 292,
+              "column": 5
+            }
+          },
+          "privacy": "public",
+          "superclass": "Vaadin.GridColumnElement",
+          "name": "Predix.DataGridSelectionColumnElement",
+          "attributes": [
+            {
+              "name": "resizable",
+              "description": "When set to true, the column is user-resizable.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 24,
+                  "column": 8
+                },
+                "end": {
+                  "line": 38,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "frozen",
+              "description": "When true, the column is frozen. When a column inside of a column group is frozen,\nall of the sibling columns inside the group will get frozen also.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 61,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "hidden",
+              "description": "When set to true, the cells for this column are hidden.",
+              "sourceRange": {
+                "file": "bower_components/vaadin-grid/vaadin-grid-column.html",
+                "start": {
+                  "line": 66,
+                  "column": 8
+                },
+                "end": {
+                  "line": 68,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "boolean",
+              "inheritedFrom": "Vaadin.Grid.ColumnBaseMixin"
+            },
+            {
+              "name": "width",
+              "description": "Width of the cells for this column.",
+              "sourceRange": {
+                "start": {
+                  "line": 61,
+                  "column": 10
+                },
+                "end": {
+                  "line": 64,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "flex-grow",
+              "description": "Flex grow ratio for the cell widths. When set to 0, cell width is fixed.",
+              "sourceRange": {
+                "start": {
+                  "line": 69,
+                  "column": 10
+                },
+                "end": {
+                  "line": 72,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "number"
+            },
+            {
+              "name": "select-all",
+              "description": "When true, all the items are selected.",
+              "sourceRange": {
+                "start": {
+                  "line": 77,
+                  "column": 10
+                },
+                "end": {
+                  "line": 81,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "auto-select",
+              "description": "When true, the active gets automatically selected.",
+              "sourceRange": {
+                "start": {
+                  "line": 86,
+                  "column": 10
+                },
+                "end": {
+                  "line": 89,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "multi-select",
+              "description": "When true, user is allowed to multiselect",
+              "sourceRange": {
+                "start": {
+                  "line": 94,
+                  "column": 10
+                },
+                "end": {
+                  "line": 97,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "tree-grid",
+              "description": "When true, the grid is in tree-grid mode (group by column/value)",
+              "sourceRange": {
+                "start": {
+                  "line": 102,
+                  "column": 10
+                },
+                "end": {
+                  "line": 104,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            },
+            {
+              "name": "is-data-column",
+              "description": "Just to help to identify columns without data",
+              "sourceRange": {
+                "start": {
+                  "line": 132,
+                  "column": 10
+                },
+                "end": {
+                  "line": 136,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "boolean"
+            }
+          ],
+          "events": [
+            {
+              "type": "CustomEvent",
+              "name": "select-all-changed",
+              "description": "Fired when the `selectAll` property changes.",
+              "metadata": {}
+            }
+          ],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-data-grid-selection-column",
+          "mixins": [
+            "Vaadin.GridColumnElement"
+          ]
+        },
+        {
+          "description": "A `<px-data-grid-string-renderer>` is standard renderer for string cell content.\nThis element shows how to implement custom renderer in order to display uncommon data.\nEach renderer that is needed for displaying content should have element with id=\"value\",\nwhich is rendered in non-editable state of the cell.\nYou may also provide element with id=\"editingTemplate\", which will display when the cell is editing.",
+          "summary": "",
+          "path": "px-data-grid-string-renderer.html",
+          "properties": [
+            {
+              "name": "__dataClientsReady",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1139,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1139,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPendingClients",
+              "type": "Array",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1141,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1141,
+                  "column": 34
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataToNotify",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1143,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1143,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataLinkedPaths",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1145,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1145,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHasPaths",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1147,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1147,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataCompoundStorage",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1149,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1149,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHost",
+              "type": "Polymer_PropertyEffects",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1151,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1151,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataTemp",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1153,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1153,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataClientsInitialized",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1155,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1155,
+                  "column": 38
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__data",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1157,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1157,
+                  "column": 20
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPending",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1159,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataOld",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1161,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1161,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__computeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1163,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1163,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__reflectEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1165,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1165,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__notifyEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1167,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1167,
+                  "column": 29
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__propagateEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1169,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1169,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__observeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1171,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1171,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__readOnly",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1173,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1173,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__templateInfo",
+              "type": "!TemplateInfo",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1175,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1175,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_template",
+              "type": "HTMLTemplateElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 424,
+                  "column": 8
+                },
+                "end": {
+                  "line": 424,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 426,
+                  "column": 8
+                },
+                "end": {
+                  "line": 426,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "rootPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 428,
+                  "column": 8
+                },
+                "end": {
+                  "line": 428,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 430,
+                  "column": 8
+                },
+                "end": {
+                  "line": 430,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "root",
+              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 432,
+                  "column": 8
+                },
+                "end": {
+                  "line": 432,
+                  "column": 18
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "$",
+              "type": "!Object.<string, !Element>",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 434,
+                  "column": 8
+                },
+                "end": {
+                  "line": 434,
+                  "column": 15
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_editing",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 11,
+                  "column": 8
+                },
+                "end": {
+                  "line": 15,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_editingChanged\""
+                }
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 17,
+                  "column": 8
+                },
+                "end": {
+                  "line": 19,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "initialValue",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 21,
+                  "column": 8
+                },
+                "end": {
+                  "line": 23,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "validationResult",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 25,
+                  "column": 8
+                },
+                "end": {
+                  "line": 27,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "column",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 29,
+                  "column": 8
+                },
+                "end": {
+                  "line": 31,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "_showValidationError",
+              "type": "boolean",
+              "description": "Boolean to pair with validation error element visibility",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 36,
+                  "column": 8
+                },
+                "end": {
+                  "line": 39,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "localize",
+              "type": "Function",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 41,
+                  "column": 8
+                },
+                "end": {
+                  "line": 41,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            }
+          ],
+          "methods": [
+            {
+              "name": "_stampTemplate",
+              "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2395,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2420,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to stamp"
+                }
+              ],
+              "return": {
+                "type": "!StampedTemplate",
+                "desc": "Cloned template content"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addMethodEventListenerToNode",
+              "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 452,
+                  "column": 6
+                },
+                "end": {
+                  "line": 457,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add listener on"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "methodName",
+                  "type": "string",
+                  "description": "Name of method"
+                },
+                {
+                  "name": "context",
+                  "type": "*=",
+                  "description": "Context the method will be called on (defaults\n  to `node`)"
+                }
+              ],
+              "return": {
+                "type": "Function",
+                "desc": "Generated handler function"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 467,
+                  "column": 6
+                },
+                "end": {
+                  "line": 469,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add event listener to"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to add"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 479,
+                  "column": 6
+                },
+                "end": {
+                  "line": 481,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to remove event listener from"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_createPropertyAccessor",
+              "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 105,
+                  "column": 8
+                },
+                "end": {
+                  "line": 118,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_definePropertyAccessor",
+              "description": "Defines a property accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 126,
+                  "column": 9
+                },
+                "end": {
+                  "line": 139,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "ready",
+              "description": "Stamps the element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 543,
+                  "column": 6
+                },
+                "end": {
+                  "line": 549,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeProperties",
+              "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 449,
+                  "column": 6
+                },
+                "end": {
+                  "line": 483,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeInstanceProperties",
+              "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 208,
+                  "column": 8
+                },
+                "end": {
+                  "line": 210,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of property values that were overwritten\n  when creating property accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setProperty",
+              "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 221,
+                  "column": 8
+                },
+                "end": {
+                  "line": 225,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_getProperty",
+              "description": "Returns the value for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 233,
+                  "column": 8
+                },
+                "end": {
+                  "line": 235,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value for the given property"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setPendingProperty",
+              "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 250,
+                  "column": 8
+                },
+                "end": {
+                  "line": 266,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "ext",
+                  "type": "boolean=",
+                  "description": "Not used here; affordance for closure"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property changed"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_invalidateProperties",
+              "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 276,
+                  "column": 8
+                },
+                "end": {
+                  "line": 286,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_enableProperties",
+              "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 299,
+                  "column": 8
+                },
+                "end": {
+                  "line": 308,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_flushProperties",
+              "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 319,
+                  "column": 8
+                },
+                "end": {
+                  "line": 325,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 339,
+                  "column": 8
+                },
+                "end": {
+                  "line": 340,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_shouldPropertyChange",
+              "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 360,
+                  "column": 8
+                },
+                "end": {
+                  "line": 367,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "New property value"
+                },
+                {
+                  "name": "old",
+                  "type": "*",
+                  "description": "Previous property value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeChangedCallback",
+              "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 379,
+                  "column": 8
+                },
+                "end": {
+                  "line": 386,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of attribute that changed"
+                },
+                {
+                  "name": "old",
+                  "type": "?string",
+                  "description": "Old attribute value"
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "New attribute value"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_attributeToProperty",
+              "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 400,
+                  "column": 8
+                },
+                "end": {
+                  "line": 407,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to deserialize."
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "of the attribute."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertyToAttribute",
+              "description": "Serializes a property to its associated attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 419,
+                  "column": 8
+                },
+                "end": {
+                  "line": 425,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name to reflect."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string=",
+                  "description": "Attribute name to reflect to."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Property value to refect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_valueToNodeAttribute",
+              "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 440,
+                  "column": 8
+                },
+                "end": {
+                  "line": 447,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Element to set attribute to."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to serialize."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Attribute name to serialize to."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_serializeValue",
+              "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 460,
+                  "column": 8
+                },
+                "end": {
+                  "line": 467,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Property value to serialize."
+                }
+              ],
+              "return": {
+                "type": "(string|undefined)",
+                "desc": "String serialized from the provided\nproperty  value."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_deserializeValue",
+              "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 481,
+                  "column": 8
+                },
+                "end": {
+                  "line": 490,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "Value to deserialize."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "Type to deserialize the string to."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Typed value deserialized from the provided string."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_initializeProtoProperties",
+              "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Properties to initialize on the prototype"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_ensureAttribute",
+              "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 186,
+                  "column": 6
+                },
+                "end": {
+                  "line": 191,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to ensure is set."
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "of the attribute."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_hasAccessor",
+              "description": "Returns true if this library created an accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 293,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if an accessor was created"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_isPropertyPending",
+              "description": "Returns true if the specified property has a pending change.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 304,
+                  "column": 6
+                },
+                "end": {
+                  "line": 306,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if property has a pending change"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_addPropertyEffect",
+              "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1247,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1255,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removePropertyEffect",
+              "description": "Removes the given property effect.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1265,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1271,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property the effect was associated with"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasPropertyEffect",
+              "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1282,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1285,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "type",
+                  "type": "string=",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReadOnlyEffect",
+              "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1295,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1297,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasNotifyEffect",
+              "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1307,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1309,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReflectEffect",
+              "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1319,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1321,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasComputedEffect",
+              "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1331,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1333,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setPendingPropertyOrPath",
+              "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1365,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1397,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(number|string)>)",
+                  "description": "Path to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "shouldNotify",
+                  "type": "boolean=",
+                  "description": "Set to true if this change should\n cause a property notification event dispatch"
+                },
+                {
+                  "name": "isPathNotification",
+                  "type": "boolean=",
+                  "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setUnmanagedPropertyToNode",
+              "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1420,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1428,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "The node to set a property on"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "The property to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "The value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_enqueueClient",
+              "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1535,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1540,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "client",
+                  "type": "Object",
+                  "description": "PropertyEffects client to enqueue"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_flushClients",
+              "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1572,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__enableOrFlushClients",
+              "description": "(c) the stamped dom enables.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1586,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1599,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_readyClients",
+              "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 570,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "setProperties",
+              "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1628,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1639,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+                },
+                {
+                  "name": "setReadOnly",
+                  "type": "boolean=",
+                  "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_propagatePropertyChanges",
+              "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1726,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1736,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "changedProps",
+                  "type": "Object",
+                  "description": "Bag of changed properties"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "linkPaths",
+              "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1747,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1752,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "to",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to link."
+                },
+                {
+                  "name": "from",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Source path to link."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unlinkPaths",
+              "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1764,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1769,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to unlink."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifySplices",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1801,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1805,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "splices",
+                  "type": "Array",
+                  "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "get",
+              "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1826,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1828,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "set",
+              "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1851,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1861,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set at the specified path."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "push",
+              "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1877,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1886,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to push onto array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "pop",
+              "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1901,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1910,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "splice",
+              "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1929,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1946,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "start",
+                  "type": "number",
+                  "description": "Index from which to start removing/inserting."
+                },
+                {
+                  "name": "deleteCount",
+                  "type": "number",
+                  "description": "Number of items to remove."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert into array."
+                }
+              ],
+              "return": {
+                "type": "Array",
+                "desc": "Array of removed items."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "shift",
+              "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1961,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1970,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unshift",
+              "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1986,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1994,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert info array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifyPath",
+              "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2009,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2026,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Value at the path (optional)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReadOnlyProperty",
+              "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2039,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2046,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createPropertyObserver",
+              "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2060,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2070,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createMethodObserver",
+              "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2083,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2089,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createNotifyingProperty",
+              "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2100,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2108,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReflectedProperty",
+              "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2119,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2132,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createComputedProperty",
+              "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2146,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2152,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_bindTemplate",
+              "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2329,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2352,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                },
+                {
+                  "name": "instanceBinding",
+                  "type": "boolean=",
+                  "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removeBoundDom",
+              "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2431,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2452,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "!StampedTemplate",
+                  "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "connectedCallback",
+              "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 530,
+                  "column": 6
+                },
+                "end": {
+                  "line": 535,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "Called when the element is removed from a document",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_attachDom",
+              "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 584,
+                  "column": 6
+                },
+                "end": {
+                  "line": 600,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "StampedTemplate",
+                  "description": "to attach to the element."
+                }
+              ],
+              "return": {
+                "type": "ShadowRoot",
+                "desc": "node to which the dom has been attached."
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "updateStyles",
+              "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 620,
+                  "column": 6
+                },
+                "end": {
+                  "line": 624,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "properties",
+                  "type": "Object=",
+                  "description": "Bag of custom property key/values to\n  apply to this element."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "resolveUrl",
+              "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 637,
+                  "column": 6
+                },
+                "end": {
+                  "line": 642,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "url",
+                  "type": "string",
+                  "description": "URL to resolve."
+                },
+                {
+                  "name": "base",
+                  "type": "string=",
+                  "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Rewritten URL relative to base"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_editingChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 51,
+                  "column": 4
+                },
+                "end": {
+                  "line": 67,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "editing"
+                },
+                {
+                  "name": "oldVal"
+                }
+              ],
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "_initialValueObserver",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 69,
+                  "column": 4
+                },
+                "end": {
+                  "line": 71,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ],
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "restoreInitial",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 73,
+                  "column": 4
+                },
+                "end": {
+                  "line": 75,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "_performValidation",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 77,
+                  "column": 4
+                },
+                "end": {
+                  "line": 82,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "validate",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 8
+                },
+                "end": {
+                  "line": 45,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "applyValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 90,
+                  "column": 4
+                },
+                "end": {
+                  "line": 97,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "getClasses",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 47,
+                  "column": 8
+                },
+                "end": {
+                  "line": 49,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "result"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "_parseTemplate",
+              "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 197,
+                  "column": 6
+                },
+                "end": {
+                  "line": 208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to parse"
+                },
+                {
+                  "name": "outerTemplateInfo",
+                  "type": "TemplateInfo=",
+                  "description": "Template metadata from the outer\n  template, for parsing nested templates"
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Parsed template metadata"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateContent",
+              "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 653,
+                  "column": 6
+                },
+                "end": {
+                  "line": 656,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "templateInfo"
+                },
+                {
+                  "name": "nodeInfo"
+                }
+              ],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_parseTemplateNode",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2471,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2485,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateChildNodes",
+              "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 258,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "root",
+                  "type": "Node",
+                  "description": "Root node whose `childNodes` will be parsed"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "!TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "!NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNestedTemplate",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2558,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2568,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateNodeAttributes",
+              "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 333,
+                  "column": 6
+                },
+                "end": {
+                  "line": 342,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNodeAttribute",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2542,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_contentForTemplate",
+              "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 388,
+                  "column": 6
+                },
+                "end": {
+                  "line": 391,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template to retrieve `content` for"
+                }
+              ],
+              "return": {
+                "type": "DocumentFragment",
+                "desc": "Content fragment"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "createProperties",
+              "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 328,
+                  "column": 7
+                },
+                "end": {
+                  "line": 332,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "attributeNameForProperty",
+              "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 76,
+                  "column": 8
+                },
+                "end": {
+                  "line": 78,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property to convert"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Attribute name corresponding to the given property."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "typeForProperty",
+              "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 174,
+                  "column": 6
+                },
+                "end": {
+                  "line": 177,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Type to which to deserialize attribute"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "createPropertiesForAttributes",
+              "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 127,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "addPropertyEffect",
+              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2192,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2194,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createPropertyObserver",
+              "description": "Creates a single-property observer for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2206,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createMethodObserver",
+              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2223,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2225,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating"
+                }
+              ],
+              "return": {
+                "type": "void",
+                "desc": "whether method names should be included as a dependency to the effect."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createNotifyingProperty",
+              "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2235,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2237,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReadOnlyProperty",
+              "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2255,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2257,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReflectedProperty",
+              "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2267,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2269,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createComputedProperty",
+              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2285,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2287,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "bindTemplate",
+              "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2301,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2303,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Template metadata object"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addTemplatePropertyEffect",
+              "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2367,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2373,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Template metadata to add effect to"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseBindings",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2603,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2668,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "description": "Text to parse from attribute or textContent"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Current template metadata"
+                }
+              ],
+              "return": {
+                "type": "Array.<!BindingPart>",
+                "desc": "Array of binding part metadata"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_evaluateBinding",
+              "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2684,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2701,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "inst",
+                  "type": "this",
+                  "description": "Element that should be used as scope for\n  binding dependencies"
+                },
+                {
+                  "name": "part",
+                  "type": "BindingPart",
+                  "description": "Binding part metadata"
+                },
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Property/path that triggered this effect"
+                },
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of current property changes"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value the binding part evaluated to"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "finalize",
+              "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 131,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_finalizeClass",
+              "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 296,
+                  "column": 5
+                },
+                "end": {
+                  "line": 319,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "createObservers",
+              "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 345,
+                  "column": 6
+                },
+                "end": {
+                  "line": 350,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "observers",
+                  "type": "Object",
+                  "description": "Array of observer descriptors for\n  this class"
+                },
+                {
+                  "name": "dynamicFns",
+                  "type": "Object",
+                  "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for a style element in the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 493,
+                  "column": 6
+                },
+                "end": {
+                  "line": 495,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "cssText",
+                  "type": "string",
+                  "description": "Text containing styling to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The processed CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 517,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            }
+          ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 35,
+              "column": 6
+            },
+            "end": {
+              "line": 50,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "Polymer.Element",
+          "name": "Predix.DataGridStringRenderer",
+          "attributes": [
+            {
+              "name": "value",
+              "description": "",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 17,
+                  "column": 8
+                },
+                "end": {
+                  "line": 19,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "initial-value",
+              "description": "",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 21,
+                  "column": 8
+                },
+                "end": {
+                  "line": 23,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "validation-result",
+              "description": "",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 25,
+                  "column": 8
+                },
+                "end": {
+                  "line": 27,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "Object",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "column",
+              "description": "",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 29,
+                  "column": 8
+                },
+                "end": {
+                  "line": 31,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "Object",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            },
+            {
+              "name": "localize",
+              "description": "",
+              "sourceRange": {
+                "file": "px-data-grid-renderer-mixin.html",
+                "start": {
+                  "line": 41,
+                  "column": 8
+                },
+                "end": {
+                  "line": 41,
+                  "column": 26
+                }
+              },
+              "metadata": {},
+              "type": "Function",
+              "inheritedFrom": "Predix.DataGridRendererMixin"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-data-grid-string-renderer",
+          "mixins": [
+            "Predix.DataGridRendererMixin"
+          ]
+        },
+        {
+          "description": "A `<px-data-grid-cell-content-wrapper>` is used to wrap user\nor generated content in order to fire proper events and observe renderers.",
+          "summary": "",
+          "path": "px-data-grid-cell-content-wrapper.html",
+          "properties": [
+            {
+              "name": "__dataClientsReady",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1139,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1139,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPendingClients",
+              "type": "Array",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1141,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1141,
+                  "column": 34
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataToNotify",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1143,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1143,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataLinkedPaths",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1145,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1145,
+                  "column": 31
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHasPaths",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1147,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1147,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataCompoundStorage",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1149,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1149,
+                  "column": 35
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataHost",
+              "type": "Polymer_PropertyEffects",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1151,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1151,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataTemp",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1153,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1153,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataClientsInitialized",
+              "type": "boolean",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1155,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1155,
+                  "column": 38
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__data",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1157,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1157,
+                  "column": 20
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataPending",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1159,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1159,
+                  "column": 27
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__dataOld",
+              "type": "!Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1161,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1161,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__computeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1163,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1163,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__reflectEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1165,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1165,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__notifyEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1167,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1167,
+                  "column": 29
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__propagateEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1169,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1169,
+                  "column": 32
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__observeEffects",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1171,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1171,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__readOnly",
+              "type": "Object",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1173,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1173,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__templateInfo",
+              "type": "!TemplateInfo",
+              "description": "",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1175,
+                  "column": 8
+                },
+                "end": {
+                  "line": 1175,
+                  "column": 28
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_template",
+              "type": "HTMLTemplateElement",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 424,
+                  "column": 8
+                },
+                "end": {
+                  "line": 424,
+                  "column": 23
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 426,
+                  "column": 8
+                },
+                "end": {
+                  "line": 426,
+                  "column": 25
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "rootPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 428,
+                  "column": 8
+                },
+                "end": {
+                  "line": 428,
+                  "column": 22
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "importPath",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 430,
+                  "column": 8
+                },
+                "end": {
+                  "line": 430,
+                  "column": 24
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "root",
+              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 432,
+                  "column": 8
+                },
+                "end": {
+                  "line": 432,
+                  "column": 18
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "$",
+              "type": "!Object.<string, !Element>",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 434,
+                  "column": 8
+                },
+                "end": {
+                  "line": 434,
+                  "column": 15
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "readOnly": false
+                }
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "item",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 21,
+                  "column": 12
+                },
+                "end": {
+                  "line": 23,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "column",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 24,
+                  "column": 12
+                },
+                "end": {
+                  "line": 26,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "cellColor",
+              "type": "string",
+              "description": "Color of cell, if 'default' will use default highlight color",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 30,
+                  "column": 12
+                },
+                "end": {
+                  "line": 33,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_cellColorChanged\""
+                }
+              }
+            },
+            {
+              "name": "_itemWas",
+              "type": "Object",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 35,
+                  "column": 12
+                },
+                "end": {
+                  "line": 38,
+                  "column": 13
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "localize",
+              "type": "Function",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 12
+                },
+                "end": {
+                  "line": 40,
+                  "column": 30
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_valueElement",
+              "type": "Element",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 42,
+                  "column": 12
+                },
+                "end": {
+                  "line": 42,
+                  "column": 34
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "_stampTemplate",
+              "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2395,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2420,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to stamp"
+                }
+              ],
+              "return": {
+                "type": "!StampedTemplate",
+                "desc": "Cloned template content"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addMethodEventListenerToNode",
+              "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 452,
+                  "column": 6
+                },
+                "end": {
+                  "line": 457,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add listener on"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "methodName",
+                  "type": "string",
+                  "description": "Name of method"
+                },
+                {
+                  "name": "context",
+                  "type": "*=",
+                  "description": "Context the method will be called on (defaults\n  to `node`)"
+                }
+              ],
+              "return": {
+                "type": "Function",
+                "desc": "Generated handler function"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_addEventListenerToNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 467,
+                  "column": 6
+                },
+                "end": {
+                  "line": 469,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "!Node",
+                  "description": "Node to add event listener to"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to add"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_removeEventListenerFromNode",
+              "description": "Override point for adding custom or simulated event handling.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 479,
+                  "column": 6
+                },
+                "end": {
+                  "line": 481,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to remove event listener from"
+                },
+                {
+                  "name": "eventName",
+                  "type": "string",
+                  "description": "Name of event"
+                },
+                {
+                  "name": "handler",
+                  "type": "Function",
+                  "description": "Listener function to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_createPropertyAccessor",
+              "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 105,
+                  "column": 8
+                },
+                "end": {
+                  "line": 118,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_definePropertyAccessor",
+              "description": "Defines a property accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 126,
+                  "column": 9
+                },
+                "end": {
+                  "line": 139,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "readOnly",
+                  "type": "boolean=",
+                  "description": "When true, no setter is created"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "ready",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 58,
+                  "column": 8
+                },
+                "end": {
+                  "line": 74,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_initializeProperties",
+              "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 449,
+                  "column": 6
+                },
+                "end": {
+                  "line": 483,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_initializeInstanceProperties",
+              "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 208,
+                  "column": 8
+                },
+                "end": {
+                  "line": 210,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of property values that were overwritten\n  when creating property accessors."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setProperty",
+              "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 221,
+                  "column": 8
+                },
+                "end": {
+                  "line": 225,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_getProperty",
+              "description": "Returns the value for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 233,
+                  "column": 8
+                },
+                "end": {
+                  "line": 235,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value for the given property"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_setPendingProperty",
+              "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 250,
+                  "column": 8
+                },
+                "end": {
+                  "line": 266,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of the property"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "ext",
+                  "type": "boolean=",
+                  "description": "Not used here; affordance for closure"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property changed"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_invalidateProperties",
+              "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 276,
+                  "column": 8
+                },
+                "end": {
+                  "line": 286,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_enableProperties",
+              "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 299,
+                  "column": 8
+                },
+                "end": {
+                  "line": 308,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_flushProperties",
+              "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 319,
+                  "column": 8
+                },
+                "end": {
+                  "line": 325,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertiesChanged",
+              "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 339,
+                  "column": 8
+                },
+                "end": {
+                  "line": 340,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "currentProps",
+                  "type": "!Object",
+                  "description": "Bag of all current accessor values"
+                },
+                {
+                  "name": "changedProps",
+                  "type": "!Object",
+                  "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "!Object",
+                  "description": "Bag of previous values for each property\n  in `changedProps`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_shouldPropertyChange",
+              "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 360,
+                  "column": 8
+                },
+                "end": {
+                  "line": 367,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "New property value"
+                },
+                {
+                  "name": "old",
+                  "type": "*",
+                  "description": "Previous property value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "attributeChangedCallback",
+              "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 379,
+                  "column": 8
+                },
+                "end": {
+                  "line": 386,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of attribute that changed"
+                },
+                {
+                  "name": "old",
+                  "type": "?string",
+                  "description": "Old attribute value"
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "New attribute value"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_attributeToProperty",
+              "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 400,
+                  "column": 8
+                },
+                "end": {
+                  "line": 407,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to deserialize."
+                },
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "of the attribute."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_propertyToAttribute",
+              "description": "Serializes a property to its associated attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 419,
+                  "column": 8
+                },
+                "end": {
+                  "line": 425,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name to reflect."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string=",
+                  "description": "Attribute name to reflect to."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Property value to refect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_valueToNodeAttribute",
+              "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 440,
+                  "column": 8
+                },
+                "end": {
+                  "line": 447,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Element to set attribute to."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to serialize."
+                },
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Attribute name to serialize to."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_serializeValue",
+              "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 460,
+                  "column": 8
+                },
+                "end": {
+                  "line": 467,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Property value to serialize."
+                }
+              ],
+              "return": {
+                "type": "(string|undefined)",
+                "desc": "String serialized from the provided\nproperty  value."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_deserializeValue",
+              "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 481,
+                  "column": 8
+                },
+                "end": {
+                  "line": 490,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value",
+                  "type": "?string",
+                  "description": "Value to deserialize."
+                },
+                {
+                  "name": "type",
+                  "type": "*=",
+                  "description": "Type to deserialize the string to."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Typed value deserialized from the provided string."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "_initializeProtoProperties",
+              "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Properties to initialize on the prototype"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_ensureAttribute",
+              "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 186,
+                  "column": 6
+                },
+                "end": {
+                  "line": 191,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "attribute",
+                  "type": "string",
+                  "description": "Name of attribute to ensure is set."
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "of the attribute."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_hasAccessor",
+              "description": "Returns true if this library created an accessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 293,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if an accessor was created"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_isPropertyPending",
+              "description": "Returns true if the specified property has a pending change.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 304,
+                  "column": 6
+                },
+                "end": {
+                  "line": 306,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if property has a pending change"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "_addPropertyEffect",
+              "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1247,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1255,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removePropertyEffect",
+              "description": "Removes the given property effect.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1265,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1271,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property the effect was associated with"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object to remove"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasPropertyEffect",
+              "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1282,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1285,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "type",
+                  "type": "string=",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReadOnlyEffect",
+              "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1295,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1297,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasNotifyEffect",
+              "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1307,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1309,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasReflectEffect",
+              "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1319,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1321,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_hasComputedEffect",
+              "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1331,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1333,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "True if the prototype/instance has an effect of this type"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setPendingPropertyOrPath",
+              "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1365,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1397,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(number|string)>)",
+                  "description": "Path to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set"
+                },
+                {
+                  "name": "shouldNotify",
+                  "type": "boolean=",
+                  "description": "Set to true if this change should\n cause a property notification event dispatch"
+                },
+                {
+                  "name": "isPathNotification",
+                  "type": "boolean=",
+                  "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_setUnmanagedPropertyToNode",
+              "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1420,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1428,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "The node to set a property on"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "The property to set"
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "The value to set"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_enqueueClient",
+              "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1535,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1540,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "client",
+                  "type": "Object",
+                  "description": "PropertyEffects client to enqueue"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_flushClients",
+              "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1572,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "__enableOrFlushClients",
+              "description": "(c) the stamped dom enables.",
+              "privacy": "private",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1586,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1599,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_readyClients",
+              "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 561,
+                  "column": 6
+                },
+                "end": {
+                  "line": 570,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "setProperties",
+              "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1628,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1639,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+                },
+                {
+                  "name": "setReadOnly",
+                  "type": "boolean=",
+                  "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_propagatePropertyChanges",
+              "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1726,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1736,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "changedProps",
+                  "type": "Object",
+                  "description": "Bag of changed properties"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "linkPaths",
+              "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1747,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1752,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "to",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to link."
+                },
+                {
+                  "name": "from",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Source path to link."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unlinkPaths",
+              "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1764,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1769,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Target path to unlink."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifySplices",
+              "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1801,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1805,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "splices",
+                  "type": "Array",
+                  "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "get",
+              "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1826,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1828,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "set",
+              "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1851,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1861,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+                },
+                {
+                  "name": "value",
+                  "type": "*",
+                  "description": "Value to set at the specified path."
+                },
+                {
+                  "name": "root",
+                  "type": "Object=",
+                  "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "push",
+              "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1877,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1886,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to push onto array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "pop",
+              "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1901,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1910,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "splice",
+              "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1929,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1946,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "start",
+                  "type": "number",
+                  "description": "Index from which to start removing/inserting."
+                },
+                {
+                  "name": "deleteCount",
+                  "type": "number",
+                  "description": "Number of items to remove."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert into array."
+                }
+              ],
+              "return": {
+                "type": "Array",
+                "desc": "Array of removed items."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "shift",
+              "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1961,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1970,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Item that was removed."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "unshift",
+              "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 1986,
+                  "column": 6
+                },
+                "end": {
+                  "line": 1994,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "(string|!Array.<(string|number)>)",
+                  "description": "Path to array."
+                },
+                {
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert info array"
+                }
+              ],
+              "return": {
+                "type": "number",
+                "desc": "New length of the array."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "notifyPath",
+              "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2009,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2026,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Path that should be notified."
+                },
+                {
+                  "name": "value",
+                  "type": "*=",
+                  "description": "Value at the path (optional)."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReadOnlyProperty",
+              "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2039,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2046,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createPropertyObserver",
+              "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2060,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2070,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createMethodObserver",
+              "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2083,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2089,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createNotifyingProperty",
+              "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2100,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2108,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createReflectedProperty",
+              "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2119,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2132,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_createComputedProperty",
+              "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2146,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2152,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_bindTemplate",
+              "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2329,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2352,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                },
+                {
+                  "name": "instanceBinding",
+                  "type": "boolean=",
+                  "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_removeBoundDom",
+              "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2431,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2452,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "!StampedTemplate",
+                  "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "connectedCallback",
+              "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 530,
+                  "column": 6
+                },
+                "end": {
+                  "line": 535,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "disconnectedCallback",
+              "description": "Called when the element is removed from a document",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 209,
+                  "column": 6
+                },
+                "end": {
+                  "line": 213,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_attachDom",
+              "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 584,
+                  "column": 6
+                },
+                "end": {
+                  "line": 600,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "dom",
+                  "type": "StampedTemplate",
+                  "description": "to attach to the element."
+                }
+              ],
+              "return": {
+                "type": "ShadowRoot",
+                "desc": "node to which the dom has been attached."
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "updateStyles",
+              "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 620,
+                  "column": 6
+                },
+                "end": {
+                  "line": 624,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "properties",
+                  "type": "Object=",
+                  "description": "Bag of custom property key/values to\n  apply to this element."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "resolveUrl",
+              "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 637,
+                  "column": 6
+                },
+                "end": {
+                  "line": 642,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "url",
+                  "type": "string",
+                  "description": "URL to resolve."
+                },
+                {
+                  "name": "base",
+                  "type": "string=",
+                  "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Rewritten URL relative to base"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_fireCellHoverEvent",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 76,
+                  "column": 8
+                },
+                "end": {
+                  "line": 88,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_fireCellUnhoverEvent",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 90,
+                  "column": 8
+                },
+                "end": {
+                  "line": 102,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_valueChangedListener",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 104,
+                  "column": 8
+                },
+                "end": {
+                  "line": 110,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "event"
+                }
+              ]
+            },
+            {
+              "name": "_cellColorChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 112,
+                  "column": 8
+                },
+                "end": {
+                  "line": 122,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "color"
+                }
+              ]
+            },
+            {
+              "name": "_render",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 124,
+                  "column": 8
+                },
+                "end": {
+                  "line": 154,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "renderer"
+                },
+                {
+                  "name": "path"
+                },
+                {
+                  "name": "editable"
+                },
+                {
+                  "name": "item"
+                },
+                {
+                  "name": "localize"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [
+            {
+              "name": "_parseTemplate",
+              "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 197,
+                  "column": 6
+                },
+                "end": {
+                  "line": 208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "!HTMLTemplateElement",
+                  "description": "Template to parse"
+                },
+                {
+                  "name": "outerTemplateInfo",
+                  "type": "TemplateInfo=",
+                  "description": "Template metadata from the outer\n  template, for parsing nested templates"
+                }
+              ],
+              "return": {
+                "type": "!TemplateInfo",
+                "desc": "Parsed template metadata"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateContent",
+              "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 653,
+                  "column": 6
+                },
+                "end": {
+                  "line": 656,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template"
+                },
+                {
+                  "name": "templateInfo"
+                },
+                {
+                  "name": "nodeInfo"
+                }
+              ],
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_parseTemplateNode",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2471,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2485,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateChildNodes",
+              "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 258,
+                  "column": 6
+                },
+                "end": {
+                  "line": 295,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "root",
+                  "type": "Node",
+                  "description": "Root node whose `childNodes` will be parsed"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "!TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "!NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNestedTemplate",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2558,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2568,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Node",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseTemplateNodeAttributes",
+              "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 333,
+                  "column": 6
+                },
+                "end": {
+                  "line": 342,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template."
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "_parseTemplateNodeAttribute",
+              "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2542,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "node",
+                  "type": "Element",
+                  "description": "Node to parse"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "TemplateInfo",
+                  "description": "Template metadata for current template"
+                },
+                {
+                  "name": "nodeInfo",
+                  "type": "NodeInfo",
+                  "description": "Node metadata for current template node"
+                },
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Attribute name"
+                },
+                {
+                  "name": "value",
+                  "type": "string",
+                  "description": "Attribute value"
+                }
+              ],
+              "return": {
+                "type": "boolean",
+                "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_contentForTemplate",
+              "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+                "start": {
+                  "line": 388,
+                  "column": 6
+                },
+                "end": {
+                  "line": 391,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template to retrieve `content` for"
+                }
+              ],
+              "return": {
+                "type": "DocumentFragment",
+                "desc": "Content fragment"
+              },
+              "inheritedFrom": "Polymer.TemplateStamp"
+            },
+            {
+              "name": "createProperties",
+              "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 328,
+                  "column": 7
+                },
+                "end": {
+                  "line": 332,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "props"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "attributeNameForProperty",
+              "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+                "start": {
+                  "line": 76,
+                  "column": 8
+                },
+                "end": {
+                  "line": 78,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property to convert"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "Attribute name corresponding to the given property."
+              },
+              "inheritedFrom": "Polymer.PropertiesChanged"
+            },
+            {
+              "name": "typeForProperty",
+              "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 174,
+                  "column": 6
+                },
+                "end": {
+                  "line": 177,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "name",
+                  "type": "string",
+                  "description": "Name of property"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Type to which to deserialize attribute"
+              },
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "createPropertiesForAttributes",
+              "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 127,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyAccessors"
+            },
+            {
+              "name": "addPropertyEffect",
+              "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2192,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2194,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "type",
+                  "type": "string",
+                  "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createPropertyObserver",
+              "description": "Creates a single-property observer for the given property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2206,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2208,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "method",
+                  "type": "(string|function (*, *))",
+                  "description": "Function or name of observer method to call"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "boolean=",
+                  "description": "Whether the method name should be included as\n  a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createMethodObserver",
+              "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2223,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2225,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating"
+                }
+              ],
+              "return": {
+                "type": "void",
+                "desc": "whether method names should be included as a dependency to the effect."
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createNotifyingProperty",
+              "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2235,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2237,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReadOnlyProperty",
+              "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2255,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2257,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                },
+                {
+                  "name": "protectedSetter",
+                  "type": "boolean=",
+                  "description": "Creates a custom protected setter\n  when `true`."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createReflectedProperty",
+              "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2267,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2269,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Property name"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "createComputedProperty",
+              "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2285,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2287,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "property",
+                  "type": "string",
+                  "description": "Name of computed property to set"
+                },
+                {
+                  "name": "expression",
+                  "type": "string",
+                  "description": "Method expression"
+                },
+                {
+                  "name": "dynamicFn",
+                  "type": "(boolean|Object)=",
+                  "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "bindTemplate",
+              "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2301,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2303,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "template",
+                  "type": "HTMLTemplateElement",
+                  "description": "Template containing binding\n  bindings"
+                }
+              ],
+              "return": {
+                "type": "Object",
+                "desc": "Template metadata object"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_addTemplatePropertyEffect",
+              "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2367,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2373,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Template metadata to add effect to"
+                },
+                {
+                  "name": "prop",
+                  "type": "string",
+                  "description": "Property that should trigger the effect"
+                },
+                {
+                  "name": "effect",
+                  "type": "Object=",
+                  "description": "Effect metadata object"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_parseBindings",
+              "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2603,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2668,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "text",
+                  "type": "string",
+                  "description": "Text to parse from attribute or textContent"
+                },
+                {
+                  "name": "templateInfo",
+                  "type": "Object",
+                  "description": "Current template metadata"
+                }
+              ],
+              "return": {
+                "type": "Array.<!BindingPart>",
+                "desc": "Array of binding part metadata"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "_evaluateBinding",
+              "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/property-effects.html",
+                "start": {
+                  "line": 2684,
+                  "column": 6
+                },
+                "end": {
+                  "line": 2701,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "inst",
+                  "type": "this",
+                  "description": "Element that should be used as scope for\n  binding dependencies"
+                },
+                {
+                  "name": "part",
+                  "type": "BindingPart",
+                  "description": "Binding part metadata"
+                },
+                {
+                  "name": "path",
+                  "type": "string",
+                  "description": "Property/path that triggered this effect"
+                },
+                {
+                  "name": "props",
+                  "type": "Object",
+                  "description": "Bag of current property changes"
+                },
+                {
+                  "name": "oldProps",
+                  "type": "Object",
+                  "description": "Bag of previous values for changed properties"
+                },
+                {
+                  "name": "hasPaths",
+                  "type": "boolean",
+                  "description": "True with `props` contains one or more paths"
+                }
+              ],
+              "return": {
+                "type": "*",
+                "desc": "Value the binding part evaluated to"
+              },
+              "inheritedFrom": "Polymer.PropertyEffects"
+            },
+            {
+              "name": "finalize",
+              "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+              "privacy": "public",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+                "start": {
+                  "line": 122,
+                  "column": 6
+                },
+                "end": {
+                  "line": 131,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Polymer.PropertiesMixin"
+            },
+            {
+              "name": "_finalizeClass",
+              "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 296,
+                  "column": 5
+                },
+                "end": {
+                  "line": 319,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "createObservers",
+              "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 345,
+                  "column": 6
+                },
+                "end": {
+                  "line": 350,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "observers",
+                  "type": "Object",
+                  "description": "Array of observer descriptors for\n  this class"
+                },
+                {
+                  "name": "dynamicFns",
+                  "type": "Object",
+                  "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_processStyleText",
+              "description": "Gather style text for a style element in the template.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 493,
+                  "column": 6
+                },
+                "end": {
+                  "line": 495,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "cssText",
+                  "type": "string",
+                  "description": "Text containing styling to process"
+                },
+                {
+                  "name": "baseURI",
+                  "type": "string",
+                  "description": "Base URI to rebase CSS paths against"
+                }
+              ],
+              "return": {
+                "type": "string",
+                "desc": "The processed CSS text"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            },
+            {
+              "name": "_finalizeTemplate",
+              "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+                "start": {
+                  "line": 506,
+                  "column": 6
+                },
+                "end": {
+                  "line": 517,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "is",
+                  "type": "string",
+                  "description": "Tag name (or type extension name) for this element"
+                }
+              ],
+              "return": {
+                "type": "void"
+              },
+              "inheritedFrom": "Polymer.ElementMixin"
+            }
+          ],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 6
+            },
+            "end": {
+              "line": 155,
+              "column": 7
+            }
+          },
+          "privacy": "public",
+          "superclass": "Polymer.Element",
+          "name": "Predix.DataGridCellContentWrapperElement",
+          "attributes": [
+            {
+              "name": "item",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 21,
+                  "column": 12
+                },
+                "end": {
+                  "line": 23,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "column",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 24,
+                  "column": 12
+                },
+                "end": {
+                  "line": 26,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "cell-color",
+              "description": "Color of cell, if 'default' will use default highlight color",
+              "sourceRange": {
+                "start": {
+                  "line": 30,
+                  "column": 12
+                },
+                "end": {
+                  "line": 33,
+                  "column": 13
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "localize",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 40,
+                  "column": 12
+                },
+                "end": {
+                  "line": 40,
+                  "column": 30
+                }
+              },
+              "metadata": {},
+              "type": "Function"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": [],
+          "tagname": "px-data-grid-cell-content-wrapper"
+        }
+      ],
+      "mixins": [
+        {
+          "description": "Mixin, that provides common functionality for all renderers.\nYou need to implement this mixin in your own renderers.",
+          "summary": "",
+          "path": "px-data-grid-renderer-mixin.html",
+          "properties": [
+            {
+              "name": "_editing",
+              "type": "boolean",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 11,
+                  "column": 8
+                },
+                "end": {
+                  "line": 15,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {
+                  "observer": "\"_editingChanged\""
+                }
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 17,
+                  "column": 8
+                },
+                "end": {
+                  "line": 19,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "initialValue",
+              "type": "string",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 21,
+                  "column": 8
+                },
+                "end": {
+                  "line": 23,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "validationResult",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 25,
+                  "column": 8
+                },
+                "end": {
+                  "line": 27,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "column",
+              "type": "Object",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 29,
+                  "column": 8
+                },
+                "end": {
+                  "line": 31,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "_showValidationError",
+              "type": "boolean",
+              "description": "Boolean to pair with validation error element visibility",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 36,
+                  "column": 8
+                },
+                "end": {
+                  "line": 39,
+                  "column": 9
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              },
+              "defaultValue": "false"
+            },
+            {
+              "name": "localize",
+              "type": "Function",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 41,
+                  "column": 8
+                },
+                "end": {
+                  "line": 41,
+                  "column": 26
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            }
+          ],
+          "methods": [
+            {
+              "name": "_editingChanged",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 51,
+                  "column": 4
+                },
+                "end": {
+                  "line": 67,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "editing"
+                },
+                {
+                  "name": "oldVal"
+                }
+              ]
+            },
+            {
+              "name": "_initialValueObserver",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 69,
+                  "column": 4
+                },
+                "end": {
+                  "line": 71,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "value"
+                }
+              ]
+            },
+            {
+              "name": "restoreInitial",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 73,
+                  "column": 4
+                },
+                "end": {
+                  "line": 75,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "_performValidation",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "start": {
+                  "line": 77,
+                  "column": 4
+                },
+                "end": {
+                  "line": 82,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "validate",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 84,
+                  "column": 4
+                },
+                "end": {
+                  "line": 88,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": []
+            },
+            {
+              "name": "applyValue",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 90,
+                  "column": 4
+                },
+                "end": {
+                  "line": 97,
+                  "column": 5
+                }
+              },
+              "metadata": {},
+              "params": []
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 8,
+              "column": 2
+            },
+            "end": {
+              "line": 99,
+              "column": 3
+            }
+          },
+          "privacy": "public",
+          "name": "Predix.DataGridRendererMixin",
+          "attributes": [
+            {
+              "name": "value",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 17,
+                  "column": 8
+                },
+                "end": {
+                  "line": 19,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "initial-value",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 21,
+                  "column": 8
+                },
+                "end": {
+                  "line": 23,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "string"
+            },
+            {
+              "name": "validation-result",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 25,
+                  "column": 8
+                },
+                "end": {
+                  "line": 27,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "column",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 29,
+                  "column": 8
+                },
+                "end": {
+                  "line": 31,
+                  "column": 9
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "localize",
+              "description": "",
+              "sourceRange": {
+                "start": {
+                  "line": 41,
+                  "column": 8
+                },
+                "end": {
+                  "line": 41,
+                  "column": 26
+                }
+              },
+              "metadata": {},
+              "type": "Function"
+            }
+          ],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": []
+        }
+      ]
+    }
+  ],
+  "elements": [
+    {
+      "description": "",
+      "summary": "",
+      "path": "px-data-grid-header-cell.html",
+      "properties": [
+        {
+          "name": "__dataClientsReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1139,
+              "column": 8
+            },
+            "end": {
+              "line": 1139,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPendingClients",
+          "type": "Array",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1141,
+              "column": 8
+            },
+            "end": {
+              "line": 1141,
+              "column": 34
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataToNotify",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1143,
+              "column": 8
+            },
+            "end": {
+              "line": 1143,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataLinkedPaths",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1145,
+              "column": 8
+            },
+            "end": {
+              "line": 1145,
+              "column": 31
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHasPaths",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1147,
+              "column": 8
+            },
+            "end": {
+              "line": 1147,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataCompoundStorage",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1149,
+              "column": 8
+            },
+            "end": {
+              "line": 1149,
+              "column": 35
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataHost",
+          "type": "Polymer_PropertyEffects",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1151,
+              "column": 8
+            },
+            "end": {
+              "line": 1151,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataTemp",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1153,
+              "column": 8
+            },
+            "end": {
+              "line": 1153,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataClientsInitialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1155,
+              "column": 8
+            },
+            "end": {
+              "line": 1155,
+              "column": 38
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__data",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1157,
+              "column": 8
+            },
+            "end": {
+              "line": 1157,
+              "column": 20
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataPending",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1159,
+              "column": 8
+            },
+            "end": {
+              "line": 1159,
+              "column": 27
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__dataOld",
+          "type": "!Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1161,
+              "column": 8
+            },
+            "end": {
+              "line": 1161,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__computeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1163,
+              "column": 8
+            },
+            "end": {
+              "line": 1163,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__reflectEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1165,
+              "column": 8
+            },
+            "end": {
+              "line": 1165,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__notifyEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1167,
+              "column": 8
+            },
+            "end": {
+              "line": 1167,
+              "column": 29
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__propagateEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1169,
+              "column": 8
+            },
+            "end": {
+              "line": 1169,
+              "column": 32
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__observeEffects",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1171,
+              "column": 8
+            },
+            "end": {
+              "line": 1171,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__readOnly",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1173,
+              "column": 8
+            },
+            "end": {
+              "line": 1173,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__templateInfo",
+          "type": "!TemplateInfo",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1175,
+              "column": 8
+            },
+            "end": {
+              "line": 1175,
+              "column": 28
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_template",
+          "type": "HTMLTemplateElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 424,
+              "column": 8
+            },
+            "end": {
+              "line": 424,
+              "column": 23
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 426,
+              "column": 8
+            },
+            "end": {
+              "line": 426,
+              "column": 25
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "rootPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 428,
+              "column": 8
+            },
+            "end": {
+              "line": 428,
+              "column": 22
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "importPath",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 430,
+              "column": 8
+            },
+            "end": {
+              "line": 430,
+              "column": 24
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "root",
+          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 432,
+              "column": 8
+            },
+            "end": {
+              "line": 432,
+              "column": 18
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "$",
+          "type": "!Object.<string, !Element>",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 434,
+              "column": 8
+            },
+            "end": {
+              "line": 434,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "dropdownOpened",
+          "type": "boolean",
+          "description": "If true, opens nested dropdown.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 25,
+              "column": 12
+            },
+            "end": {
+              "line": 28,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_dropdownOpenedChanged\""
+            }
+          }
+        },
+        {
+          "name": "_dropdownHidden",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 30,
+              "column": 12
+            },
+            "end": {
+              "line": 33,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "_mouseover",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 35,
+              "column": 12
+            },
+            "end": {
+              "line": 38,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_column",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 40,
+              "column": 12
+            },
+            "end": {
+              "line": 42,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_dropdownItems",
+          "type": "Array",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 44,
+              "column": 12
+            },
+            "end": {
+              "line": 46,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "localize",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 12
+            },
+            "end": {
+              "line": 48,
+              "column": 30
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "_stampTemplate",
+          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2395,
+              "column": 6
+            },
+            "end": {
+              "line": 2420,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to stamp"
+            }
+          ],
+          "return": {
+            "type": "!StampedTemplate",
+            "desc": "Cloned template content"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addMethodEventListenerToNode",
+          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 452,
+              "column": 6
+            },
+            "end": {
+              "line": 457,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add listener on"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "methodName",
+              "type": "string",
+              "description": "Name of method"
+            },
+            {
+              "name": "context",
+              "type": "*=",
+              "description": "Context the method will be called on (defaults\n  to `node`)"
+            }
+          ],
+          "return": {
+            "type": "Function",
+            "desc": "Generated handler function"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_addEventListenerToNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 467,
+              "column": 6
+            },
+            "end": {
+              "line": 469,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "!Node",
+              "description": "Node to add event listener to"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to add"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_removeEventListenerFromNode",
+          "description": "Override point for adding custom or simulated event handling.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 479,
+              "column": 6
+            },
+            "end": {
+              "line": 481,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to remove event listener from"
+            },
+            {
+              "name": "eventName",
+              "type": "string",
+              "description": "Name of event"
+            },
+            {
+              "name": "handler",
+              "type": "Function",
+              "description": "Listener function to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_createPropertyAccessor",
+          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 105,
+              "column": 8
+            },
+            "end": {
+              "line": 118,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_definePropertyAccessor",
+          "description": "Defines a property accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 126,
+              "column": 9
+            },
+            "end": {
+              "line": 139,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "readOnly",
+              "type": "boolean=",
+              "description": "When true, no setter is created"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 58,
+              "column": 8
+            },
+            "end": {
+              "line": 72,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_initializeProperties",
+          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 449,
+              "column": 6
+            },
+            "end": {
+              "line": 483,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_initializeInstanceProperties",
+          "description": "Called at ready time with bag of instance properties that overwrote\naccessors when the element upgraded.\n\nThe default implementation sets these properties back into the\nsetter at ready time.  This method is provided as an override\npoint for customizing or providing more efficient initialization.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 208,
+              "column": 8
+            },
+            "end": {
+              "line": 210,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of property values that were overwritten\n  when creating property accessors."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setProperty",
+          "description": "Updates the local storage for a property (via `_setPendingProperty`)\nand enqueues a `_proeprtiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 221,
+              "column": 8
+            },
+            "end": {
+              "line": 225,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_getProperty",
+          "description": "Returns the value for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 233,
+              "column": 8
+            },
+            "end": {
+              "line": 235,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of property"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value for the given property"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_setPendingProperty",
+          "description": "Updates the local storage for a property, records the previous value,\nand adds it to the set of \"pending changes\" that will be passed to the\n`_propertiesChanged` callback.  This method does not enqueue the\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 250,
+              "column": 8
+            },
+            "end": {
+              "line": 266,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of the property"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "ext",
+              "type": "boolean=",
+              "description": "Not used here; affordance for closure"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property changed"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_invalidateProperties",
+          "description": "Marks the properties as invalid, and enqueues an async\n`_propertiesChanged` callback.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 276,
+              "column": 8
+            },
+            "end": {
+              "line": 286,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_enableProperties",
+          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 299,
+              "column": 8
+            },
+            "end": {
+              "line": 308,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_flushProperties",
+          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 319,
+              "column": 8
+            },
+            "end": {
+              "line": 325,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertiesChanged",
+          "description": "Callback called when any properties with accessors created via\n`_createPropertyAccessor` have been set.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 339,
+              "column": 8
+            },
+            "end": {
+              "line": 340,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "currentProps",
+              "type": "!Object",
+              "description": "Bag of all current accessor values"
+            },
+            {
+              "name": "changedProps",
+              "type": "!Object",
+              "description": "Bag of properties changed since the last\n  call to `_propertiesChanged`"
+            },
+            {
+              "name": "oldProps",
+              "type": "!Object",
+              "description": "Bag of previous values for each property\n  in `changedProps`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_shouldPropertyChange",
+          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` if a strict equality\ncheck fails. The method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 360,
+              "column": 8
+            },
+            "end": {
+              "line": 367,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "New property value"
+            },
+            {
+              "name": "old",
+              "type": "*",
+              "description": "Previous property value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Whether the property should be considered a change\n  and enqueue a `_proeprtiesChanged` callback"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "attributeChangedCallback",
+          "description": "Implements native Custom Elements `attributeChangedCallback` to\nset an attribute value to a property via `_attributeToProperty`.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 379,
+              "column": 8
+            },
+            "end": {
+              "line": 386,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of attribute that changed"
+            },
+            {
+              "name": "old",
+              "type": "?string",
+              "description": "Old attribute value"
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "New attribute value"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_attributeToProperty",
+          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 400,
+              "column": 8
+            },
+            "end": {
+              "line": 407,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to deserialize."
+            },
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "of the attribute."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "type to deserialize to, defaults to the value\nreturned from `typeForProperty`"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_propertyToAttribute",
+          "description": "Serializes a property to its associated attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 419,
+              "column": 8
+            },
+            "end": {
+              "line": 425,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name to reflect."
+            },
+            {
+              "name": "attribute",
+              "type": "string=",
+              "description": "Attribute name to reflect to."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Property value to refect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_valueToNodeAttribute",
+          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 440,
+              "column": 8
+            },
+            "end": {
+              "line": 447,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Element to set attribute to."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to serialize."
+            },
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Attribute name to serialize to."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_serializeValue",
+          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called when setting JS property values to\nHTML attributes.  Users may override this method to provide\nserialization for custom types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 460,
+              "column": 8
+            },
+            "end": {
+              "line": 467,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Property value to serialize."
+            }
+          ],
+          "return": {
+            "type": "(string|undefined)",
+            "desc": "String serialized from the provided\nproperty  value."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_deserializeValue",
+          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called when reading HTML attribute values to\nJS properties.  Users may override this method to provide\ndeserialization for custom `type`s. Types for `Boolean`, `String`,\nand `Number` convert attributes to the expected types.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 481,
+              "column": 8
+            },
+            "end": {
+              "line": 490,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "value",
+              "type": "?string",
+              "description": "Value to deserialize."
+            },
+            {
+              "name": "type",
+              "type": "*=",
+              "description": "Type to deserialize the string to."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Typed value deserialized from the provided string."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "_initializeProtoProperties",
+          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1209,
+              "column": 6
+            },
+            "end": {
+              "line": 1213,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Properties to initialize on the prototype"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_ensureAttribute",
+          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 186,
+              "column": 6
+            },
+            "end": {
+              "line": 191,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "attribute",
+              "type": "string",
+              "description": "Name of attribute to ensure is set."
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "of the attribute."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_hasAccessor",
+          "description": "Returns true if this library created an accessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 293,
+              "column": 6
+            },
+            "end": {
+              "line": 295,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if an accessor was created"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_isPropertyPending",
+          "description": "Returns true if the specified property has a pending change.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 304,
+              "column": 6
+            },
+            "end": {
+              "line": 306,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if property has a pending change"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "_addPropertyEffect",
+          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1247,
+              "column": 6
+            },
+            "end": {
+              "line": 1255,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removePropertyEffect",
+          "description": "Removes the given property effect.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1265,
+              "column": 6
+            },
+            "end": {
+              "line": 1271,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property the effect was associated with"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object to remove"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasPropertyEffect",
+          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1282,
+              "column": 6
+            },
+            "end": {
+              "line": 1285,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "type",
+              "type": "string=",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReadOnlyEffect",
+          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1295,
+              "column": 6
+            },
+            "end": {
+              "line": 1297,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasNotifyEffect",
+          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1307,
+              "column": 6
+            },
+            "end": {
+              "line": 1309,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasReflectEffect",
+          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1319,
+              "column": 6
+            },
+            "end": {
+              "line": 1321,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_hasComputedEffect",
+          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1331,
+              "column": 6
+            },
+            "end": {
+              "line": 1333,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "True if the prototype/instance has an effect of this type"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setPendingPropertyOrPath",
+          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1365,
+              "column": 6
+            },
+            "end": {
+              "line": 1397,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(number|string)>)",
+              "description": "Path to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set"
+            },
+            {
+              "name": "shouldNotify",
+              "type": "boolean=",
+              "description": "Set to true if this change should\n cause a property notification event dispatch"
+            },
+            {
+              "name": "isPathNotification",
+              "type": "boolean=",
+              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_setUnmanagedPropertyToNode",
+          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1420,
+              "column": 6
+            },
+            "end": {
+              "line": 1428,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "The node to set a property on"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "The property to set"
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "The value to set"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_enqueueClient",
+          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1535,
+              "column": 6
+            },
+            "end": {
+              "line": 1540,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "client",
+              "type": "Object",
+              "description": "PropertyEffects client to enqueue"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_flushClients",
+          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1561,
+              "column": 6
+            },
+            "end": {
+              "line": 1572,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "__enableOrFlushClients",
+          "description": "(c) the stamped dom enables.",
+          "privacy": "private",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1586,
+              "column": 6
+            },
+            "end": {
+              "line": 1599,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_readyClients",
+          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 561,
+              "column": 6
+            },
+            "end": {
+              "line": 570,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "setProperties",
+          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1628,
+              "column": 6
+            },
+            "end": {
+              "line": 1639,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
+            },
+            {
+              "name": "setReadOnly",
+              "type": "boolean=",
+              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_propagatePropertyChanges",
+          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1726,
+              "column": 6
+            },
+            "end": {
+              "line": 1736,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "changedProps",
+              "type": "Object",
+              "description": "Bag of changed properties"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "linkPaths",
+          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1747,
+              "column": 6
+            },
+            "end": {
+              "line": 1752,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "to",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to link."
+            },
+            {
+              "name": "from",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Source path to link."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unlinkPaths",
+          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1764,
+              "column": 6
+            },
+            "end": {
+              "line": 1769,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Target path to unlink."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifySplices",
+          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1801,
+              "column": 6
+            },
+            "end": {
+              "line": 1805,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "splices",
+              "type": "Array",
+              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "get",
+          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1826,
+              "column": 6
+            },
+            "end": {
+              "line": 1828,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "set",
+          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1851,
+              "column": 6
+            },
+            "end": {
+              "line": 1861,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
+            },
+            {
+              "name": "value",
+              "type": "*",
+              "description": "Value to set at the specified path."
+            },
+            {
+              "name": "root",
+              "type": "Object=",
+              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "push",
+          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1877,
+              "column": 6
+            },
+            "end": {
+              "line": 1886,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to push onto array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "pop",
+          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1901,
+              "column": 6
+            },
+            "end": {
+              "line": 1910,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "splice",
+          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1929,
+              "column": 6
+            },
+            "end": {
+              "line": 1946,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "start",
+              "type": "number",
+              "description": "Index from which to start removing/inserting."
+            },
+            {
+              "name": "deleteCount",
+              "type": "number",
+              "description": "Number of items to remove."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert into array."
+            }
+          ],
+          "return": {
+            "type": "Array",
+            "desc": "Array of removed items."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "shift",
+          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1961,
+              "column": 6
+            },
+            "end": {
+              "line": 1970,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Item that was removed."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "unshift",
+          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 1986,
+              "column": 6
+            },
+            "end": {
+              "line": 1994,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "(string|!Array.<(string|number)>)",
+              "description": "Path to array."
+            },
+            {
+              "name": "items",
+              "type": "...*",
+              "rest": true,
+              "description": "Items to insert info array"
+            }
+          ],
+          "return": {
+            "type": "number",
+            "desc": "New length of the array."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "notifyPath",
+          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2009,
+              "column": 6
+            },
+            "end": {
+              "line": 2026,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Path that should be notified."
+            },
+            {
+              "name": "value",
+              "type": "*=",
+              "description": "Value at the path (optional)."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReadOnlyProperty",
+          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2039,
+              "column": 6
+            },
+            "end": {
+              "line": 2046,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createPropertyObserver",
+          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2060,
+              "column": 6
+            },
+            "end": {
+              "line": 2070,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string|function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createMethodObserver",
+          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2083,
+              "column": 6
+            },
+            "end": {
+              "line": 2089,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createNotifyingProperty",
+          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2100,
+              "column": 6
+            },
+            "end": {
+              "line": 2108,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createReflectedProperty",
+          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2119,
+              "column": 6
+            },
+            "end": {
+              "line": 2132,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_createComputedProperty",
+          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2146,
+              "column": 6
+            },
+            "end": {
+              "line": 2152,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_bindTemplate",
+          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2329,
+              "column": 6
+            },
+            "end": {
+              "line": 2352,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            },
+            {
+              "name": "instanceBinding",
+              "type": "boolean=",
+              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_removeBoundDom",
+          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2431,
+              "column": 6
+            },
+            "end": {
+              "line": 2452,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "!StampedTemplate",
+              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "connectedCallback",
+          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 530,
+              "column": 6
+            },
+            "end": {
+              "line": 535,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "disconnectedCallback",
+          "description": "Called when the element is removed from a document",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 209,
+              "column": 6
+            },
+            "end": {
+              "line": 213,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_attachDom",
+          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 584,
+              "column": 6
+            },
+            "end": {
+              "line": 600,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dom",
+              "type": "StampedTemplate",
+              "description": "to attach to the element."
+            }
+          ],
+          "return": {
+            "type": "ShadowRoot",
+            "desc": "node to which the dom has been attached."
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "updateStyles",
+          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 620,
+              "column": 6
+            },
+            "end": {
+              "line": 624,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "properties",
+              "type": "Object=",
+              "description": "Bag of custom property key/values to\n  apply to this element."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "resolveUrl",
+          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 637,
+              "column": 6
+            },
+            "end": {
+              "line": 642,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url",
+              "type": "string",
+              "description": "URL to resolve."
+            },
+            {
+              "name": "base",
+              "type": "string=",
+              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Rewritten URL relative to base"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_freezeColumn",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 74,
+              "column": 8
+            },
+            "end": {
+              "line": 86,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_unfreezeColumn",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 88,
+              "column": 8
+            },
+            "end": {
+              "line": 100,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_hideColumn",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 102,
+              "column": 8
+            },
+            "end": {
+              "line": 104,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_groupByColumn",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 106,
+              "column": 8
+            },
+            "end": {
+              "line": 118,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_ungroup",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 120,
+              "column": 8
+            },
+            "end": {
+              "line": 132,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_setDropdownItems",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 134,
+              "column": 8
+            },
+            "end": {
+              "line": 188,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_dropdownOpenedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 190,
+              "column": 8
+            },
+            "end": {
+              "line": 204,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "dropdownOpened"
+            }
+          ]
+        },
+        {
+          "name": "_dropdownSelectedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 206,
+              "column": 8
+            },
+            "end": {
+              "line": 211,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "e"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [
+        {
+          "name": "_parseTemplate",
+          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 197,
+              "column": 6
+            },
+            "end": {
+              "line": 208,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "!HTMLTemplateElement",
+              "description": "Template to parse"
+            },
+            {
+              "name": "outerTemplateInfo",
+              "type": "TemplateInfo=",
+              "description": "Template metadata from the outer\n  template, for parsing nested templates"
+            }
+          ],
+          "return": {
+            "type": "!TemplateInfo",
+            "desc": "Parsed template metadata"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateContent",
+          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 653,
+              "column": 6
+            },
+            "end": {
+              "line": 656,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template"
+            },
+            {
+              "name": "templateInfo"
+            },
+            {
+              "name": "nodeInfo"
+            }
+          ],
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_parseTemplateNode",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2471,
+              "column": 6
+            },
+            "end": {
+              "line": 2485,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateChildNodes",
+          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 258,
+              "column": 6
+            },
+            "end": {
+              "line": 295,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "root",
+              "type": "Node",
+              "description": "Root node whose `childNodes` will be parsed"
+            },
+            {
+              "name": "templateInfo",
+              "type": "!TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "!NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNestedTemplate",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2558,
+              "column": 6
+            },
+            "end": {
+              "line": 2568,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Node",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseTemplateNodeAttributes",
+          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 333,
+              "column": 6
+            },
+            "end": {
+              "line": 342,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template."
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "_parseTemplateNodeAttribute",
+          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2506,
+              "column": 6
+            },
+            "end": {
+              "line": 2542,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "node",
+              "type": "Element",
+              "description": "Node to parse"
+            },
+            {
+              "name": "templateInfo",
+              "type": "TemplateInfo",
+              "description": "Template metadata for current template"
+            },
+            {
+              "name": "nodeInfo",
+              "type": "NodeInfo",
+              "description": "Node metadata for current template node"
+            },
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Attribute name"
+            },
+            {
+              "name": "value",
+              "type": "string",
+              "description": "Attribute value"
+            }
+          ],
+          "return": {
+            "type": "boolean",
+            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_contentForTemplate",
+          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/template-stamp.html",
+            "start": {
+              "line": 388,
+              "column": 6
+            },
+            "end": {
+              "line": 391,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template to retrieve `content` for"
+            }
+          ],
+          "return": {
+            "type": "DocumentFragment",
+            "desc": "Content fragment"
+          },
+          "inheritedFrom": "Polymer.TemplateStamp"
+        },
+        {
+          "name": "createProperties",
+          "description": "Override of PropertiesChanged createProperties to create accessors\nand property effects for all of the properties.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 328,
+              "column": 7
+            },
+            "end": {
+              "line": 332,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "props"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "attributeNameForProperty",
+          "description": "Returns an attribute name that corresponds to the given property.\nThe attribute name is the lowercased property name. Override to\ncustomize this mapping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-changed.html",
+            "start": {
+              "line": 76,
+              "column": 8
+            },
+            "end": {
+              "line": 78,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property to convert"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "Attribute name corresponding to the given property."
+          },
+          "inheritedFrom": "Polymer.PropertiesChanged"
+        },
+        {
+          "name": "typeForProperty",
+          "description": "Overrides `PropertiesChanged` method to return type specified in the\nstatic `properties` object for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 174,
+              "column": 6
+            },
+            "end": {
+              "line": 177,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "name",
+              "type": "string",
+              "description": "Name of property"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Type to which to deserialize attribute"
+          },
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "createPropertiesForAttributes",
+          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-accessors.html",
+            "start": {
+              "line": 122,
+              "column": 6
+            },
+            "end": {
+              "line": 127,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyAccessors"
+        },
+        {
+          "name": "addPropertyEffect",
+          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2192,
+              "column": 6
+            },
+            "end": {
+              "line": 2194,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "type",
+              "type": "string",
+              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createPropertyObserver",
+          "description": "Creates a single-property observer for the given property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2206,
+              "column": 6
+            },
+            "end": {
+              "line": 2208,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "method",
+              "type": "(string|function (*, *))",
+              "description": "Function or name of observer method to call"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "boolean=",
+              "description": "Whether the method name should be included as\n  a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createMethodObserver",
+          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2223,
+              "column": 6
+            },
+            "end": {
+              "line": 2225,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating"
+            }
+          ],
+          "return": {
+            "type": "void",
+            "desc": "whether method names should be included as a dependency to the effect."
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createNotifyingProperty",
+          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2235,
+              "column": 6
+            },
+            "end": {
+              "line": 2237,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReadOnlyProperty",
+          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2255,
+              "column": 6
+            },
+            "end": {
+              "line": 2257,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            },
+            {
+              "name": "protectedSetter",
+              "type": "boolean=",
+              "description": "Creates a custom protected setter\n  when `true`."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createReflectedProperty",
+          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2267,
+              "column": 6
+            },
+            "end": {
+              "line": 2269,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Property name"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "createComputedProperty",
+          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2285,
+              "column": 6
+            },
+            "end": {
+              "line": 2287,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "property",
+              "type": "string",
+              "description": "Name of computed property to set"
+            },
+            {
+              "name": "expression",
+              "type": "string",
+              "description": "Method expression"
+            },
+            {
+              "name": "dynamicFn",
+              "type": "(boolean|Object)=",
+              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "bindTemplate",
+          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2301,
+              "column": 6
+            },
+            "end": {
+              "line": 2303,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "template",
+              "type": "HTMLTemplateElement",
+              "description": "Template containing binding\n  bindings"
+            }
+          ],
+          "return": {
+            "type": "Object",
+            "desc": "Template metadata object"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_addTemplatePropertyEffect",
+          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2367,
+              "column": 6
+            },
+            "end": {
+              "line": 2373,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Template metadata to add effect to"
+            },
+            {
+              "name": "prop",
+              "type": "string",
+              "description": "Property that should trigger the effect"
+            },
+            {
+              "name": "effect",
+              "type": "Object=",
+              "description": "Effect metadata object"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_parseBindings",
+          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2603,
+              "column": 6
+            },
+            "end": {
+              "line": 2668,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "string",
+              "description": "Text to parse from attribute or textContent"
+            },
+            {
+              "name": "templateInfo",
+              "type": "Object",
+              "description": "Current template metadata"
+            }
+          ],
+          "return": {
+            "type": "Array.<!BindingPart>",
+            "desc": "Array of binding part metadata"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "_evaluateBinding",
+          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/property-effects.html",
+            "start": {
+              "line": 2684,
+              "column": 6
+            },
+            "end": {
+              "line": 2701,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "inst",
+              "type": "this",
+              "description": "Element that should be used as scope for\n  binding dependencies"
+            },
+            {
+              "name": "part",
+              "type": "BindingPart",
+              "description": "Binding part metadata"
+            },
+            {
+              "name": "path",
+              "type": "string",
+              "description": "Property/path that triggered this effect"
+            },
+            {
+              "name": "props",
+              "type": "Object",
+              "description": "Bag of current property changes"
+            },
+            {
+              "name": "oldProps",
+              "type": "Object",
+              "description": "Bag of previous values for changed properties"
+            },
+            {
+              "name": "hasPaths",
+              "type": "boolean",
+              "description": "True with `props` contains one or more paths"
+            }
+          ],
+          "return": {
+            "type": "*",
+            "desc": "Value the binding part evaluated to"
+          },
+          "inheritedFrom": "Polymer.PropertyEffects"
+        },
+        {
+          "name": "finalize",
+          "description": "Finalizes an element definition, including ensuring any super classes\nare also finalized. This includes ensuring property\naccessors exist on the element prototype. This method calls\n`_finalizeClass` to finalize each constructor in the prototype chain.",
+          "privacy": "public",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/properties-mixin.html",
+            "start": {
+              "line": 122,
+              "column": 6
+            },
+            "end": {
+              "line": 131,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "Polymer.PropertiesMixin"
+        },
+        {
+          "name": "_finalizeClass",
+          "description": "Override of PropertiesMixin _finalizeClass to create observers and\nfind the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 296,
+              "column": 5
+            },
+            "end": {
+              "line": 319,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "createObservers",
+          "description": "Creates observers for the given `observers` array.\nLeverages `PropertyEffects` to create observers.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 345,
+              "column": 6
+            },
+            "end": {
+              "line": 350,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "observers",
+              "type": "Object",
+              "description": "Array of observer descriptors for\n  this class"
+            },
+            {
+              "name": "dynamicFns",
+              "type": "Object",
+              "description": "Object containing keys for any properties\n  that are functions and should trigger the effect when the function\n  reference is changed"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_processStyleText",
+          "description": "Gather style text for a style element in the template.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 493,
+              "column": 6
+            },
+            "end": {
+              "line": 495,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "cssText",
+              "type": "string",
+              "description": "Text containing styling to process"
+            },
+            {
+              "name": "baseURI",
+              "type": "string",
+              "description": "Base URI to rebase CSS paths against"
+            }
+          ],
+          "return": {
+            "type": "string",
+            "desc": "The processed CSS text"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        },
+        {
+          "name": "_finalizeTemplate",
+          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "bower_components/polymer/lib/mixins/element-mixin.html",
+            "start": {
+              "line": 506,
+              "column": 6
+            },
+            "end": {
+              "line": 517,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "is",
+              "type": "string",
+              "description": "Tag name (or type extension name) for this element"
+            }
+          ],
+          "return": {
+            "type": "void"
+          },
+          "inheritedFrom": "Polymer.ElementMixin"
+        }
+      ],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 6
+        },
+        "end": {
+          "line": 213,
+          "column": 7
+        }
+      },
+      "privacy": "public",
+      "superclass": "Polymer.Element",
+      "name": "DataGridHeaderCellElement",
+      "attributes": [
+        {
+          "name": "dropdown-opened",
+          "description": "If true, opens nested dropdown.",
+          "sourceRange": {
+            "start": {
+              "line": 25,
+              "column": 12
+            },
+            "end": {
+              "line": 28,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "localize",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 48,
+              "column": 12
+            },
+            "end": {
+              "line": 48,
+              "column": 30
+            }
+          },
+          "metadata": {},
+          "type": "Function"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "px-data-grid-header-cell.html",
+            "start": {
+              "line": 11,
+              "column": 4
+            },
+            "end": {
+              "line": 11,
+              "column": 17
+            }
+          }
+        }
+      ],
+      "tagname": "px-data-grid-header-cell"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "px-data-grid-paginated.html",
+      "properties": [
+        {
+          "name": "tableData",
+          "type": "Array",
+          "description": "Data for the table to display.\n\nExpected data format is a JSON array of objects. Each object in the array represents a row in the table.\n\nEach item in an object will be displayed as a separate column, unless px-data-table-columns are\ndefined to limit which columns are displayed.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 12
+            },
+            "end": {
+              "line": 72,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_tableDataChanged\""
+            }
+          }
+        },
+        {
+          "name": "seletionMode",
+          "type": "string",
+          "description": "Current selection mode of grid. Accepts values 'none', 'single' and 'multi'.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 77,
+              "column": 12
+            },
+            "end": {
+              "line": 80,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"none\""
+        },
+        {
+          "name": "hideSelectionColumn",
+          "type": "boolean",
+          "description": "If true, hides the column with checkboxes.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 85,
+              "column": 12
+            },
+            "end": {
+              "line": 88,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "selectedItems",
+          "type": "Array",
+          "description": "An array that contains the selected items.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 93,
+              "column": 12
+            },
+            "end": {
+              "line": 97,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "size",
+          "type": "number",
+          "description": "The total number of items",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 102,
+              "column": 12
+            },
+            "end": {
+              "line": 106,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_ensureValidPageNumber\""
+            }
+          }
+        },
+        {
+          "name": "pageSize",
+          "type": "number",
+          "description": "Number of items fetched at a time from the dataprovider.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 111,
+              "column": 12
+            },
+            "end": {
+              "line": 115,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_onPageSizeChange\""
+            }
+          },
+          "defaultValue": "10"
+        },
+        {
+          "name": "selectablePageSizes",
+          "type": "Array",
+          "description": "Array of selectable page sizes offered to the user.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 120,
+              "column": 12
+            },
+            "end": {
+              "line": 123,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[10,20,30]"
+        },
+        {
+          "name": "page",
+          "type": "number",
+          "description": "Current page number of displayed items. Page 1 should be the minimum value.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 128,
+              "column": 12
+            },
+            "end": {
+              "line": 132,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_onPageChange\""
+            }
+          },
+          "defaultValue": "1"
+        },
+        {
+          "name": "multiSort",
+          "type": "boolean",
+          "description": "When `true`, user can sort by multiple columns",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 137,
+              "column": 12
+            },
+            "end": {
+              "line": 140,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "activeItem",
+          "type": "Object",
+          "description": "The item user has last interacted with. Turns to `null` after user deactivates\nthe item by re-interacting with the currently active item.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 146,
+              "column": 12
+            },
+            "end": {
+              "line": 150,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "resizable",
+          "type": "boolean",
+          "description": "When `true`, user can resize columns",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 155,
+              "column": 12
+            },
+            "end": {
+              "line": 158,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "columnReorderingAllowed",
+          "type": "boolean",
+          "description": "Set to true to allow column reordering.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 163,
+              "column": 12
+            },
+            "end": {
+              "line": 166,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "expandedItems",
+          "type": "Array",
+          "description": "An array containing references to expanded items.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 171,
+              "column": 12
+            },
+            "end": {
+              "line": 174,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "actionMenu",
+          "type": "boolean",
+          "description": "Define if table action menu is shown or not",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 179,
+              "column": 12
+            },
+            "end": {
+              "line": 182,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "columns",
+          "type": "Array",
+          "description": "Grid columns. If no columns are passed, grid generates columns from passed data.\nFormat:\n```javascript\n{\n  name: 'first',\n  hidden: false,\n  header: 'First name',\n  value: (item) => {\n    return item.first;\n  }\n},\n```\nIn case px-data-table-columns aren't provided, table columns will be generated automatically.\nThey will be stamped via\n\n<template is=\"dom-repeat\" items=\"[[_generatedColumns]]\">\n  ...\n</template>",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 206,
+              "column": 12
+            },
+            "end": {
+              "line": 209,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "language",
+          "type": "string",
+          "description": "A valid IETF language tag as a string that `app-localize-behavior` will\nuse to localize this component.\n\nSee https://github.com/PolymerElements/app-localize-behavior for API\ndocumentation and more information.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 218,
+              "column": 12
+            },
+            "end": {
+              "line": 221,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"en\""
+        },
+        {
+          "name": "useKeyIfMissing",
+          "type": "boolean",
+          "description": "Use the key for localization if value for that language is missing.\nShould always be true for Predix components.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 227,
+              "column": 12
+            },
+            "end": {
+              "line": 230,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "resources",
+          "type": "Object",
+          "description": "Library object of hardcoded strings used in this application.\nUsed by `app-localize-behavior` in conjunction with `language`.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 236,
+              "column": 12
+            },
+            "end": {
+              "line": 254,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "{\"en\":{\"Rows per page\":\"Rows per page\",\"of {total}\":\"of {total}\"},\"fr\":{\"Rows per page\":\"Lignes par page\",\"of {total}\":\"sur {total}\"},\"fi\":{\"Rows per page\":\"Riviä / sivu\",\"of {total}\":\"/ {total}\"}}"
+        },
+        {
+          "name": "tableActions",
+          "type": "Array",
+          "description": "All custom table actions. Should return array of objects with 'name' (String) and 'action' (function).",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 259,
+              "column": 12
+            },
+            "end": {
+              "line": 262,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "remoteDataProvider",
+          "type": "Function",
+          "description": "Function that provides items lazily. Receives arguments params, callback",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 267,
+              "column": 12
+            },
+            "end": {
+              "line": 270,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_remoteDataProviderChanged\""
+            }
+          }
+        },
+        {
+          "name": "_currentDataProvider",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 272,
+              "column": 12
+            },
+            "end": {
+              "line": 274,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "striped",
+          "type": "boolean",
+          "description": "If true, every other row in the table will appear with a background color to improve visual scanning.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 279,
+              "column": 12
+            },
+            "end": {
+              "line": 282,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "loadingSpinnerDebounce",
+          "type": "number",
+          "description": "How many milliseconds before loading spinner will be shown",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 288,
+              "column": 12
+            },
+            "end": {
+              "line": 291,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "500"
+        },
+        {
+          "name": "autoFilter",
+          "type": "boolean",
+          "description": "To enable automatic filtering change property to true",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 296,
+              "column": 12
+            },
+            "end": {
+              "line": 299,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "highlight",
+          "type": "Array",
+          "description": "Array of objects of conditions used to highlight specific columns.\nFormat:\n```javascript\n{\n  type: 'cell',\n  condition: (cellContent, column, item) => { return cellContent == 'John Doe' },\n},\n{\n  type: 'row',\n  condition: (cellContent, item) => { return cellContent[0] == 'a' },\n  color: '#a8a8a8'\n},\n{\n  type: 'column',\n  condition (column, item) => { return column.name == 'age' },\n  color: 'pink'\n}\n```",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 321,
+              "column": 12
+            },
+            "end": {
+              "line": 324,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "_hasLocalDataProvider",
+          "type": "boolean",
+          "description": "When true data provider is local, when false external (remote) and\nwhen undefined it defined yet.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 330,
+              "column": 12
+            },
+            "end": {
+              "line": 332,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "defaultColumnWidth",
+          "type": "string",
+          "description": "Default column width if not defined, eg. '100px'",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 337,
+              "column": 12
+            },
+            "end": {
+              "line": 340,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"100px\""
+        },
+        {
+          "name": "defaultColumnFlex",
+          "type": "number",
+          "description": "Default column flex if not defined, eg. 1",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 345,
+              "column": 12
+            },
+            "end": {
+              "line": 348,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "1"
+        },
+        {
+          "name": "gridHeight",
+          "type": "string",
+          "description": "Grid auto resize height to match number of rows.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 353,
+              "column": 12
+            },
+            "end": {
+              "line": 356,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"auto\""
+        },
+        {
+          "name": "itemIdPath",
+          "type": "string",
+          "description": "Path to an item sub-property that identifies the item.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 361,
+              "column": 12
+            },
+            "end": {
+              "line": 364,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "autoHidePageList",
+          "type": "boolean",
+          "description": "If true, automatically hides the page numbers list when there is only\n1 page available.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 370,
+              "column": 12
+            },
+            "end": {
+              "line": 373,
+              "column": 13
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 378,
+              "column": 8
+            },
+            "end": {
+              "line": 381,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_tableDataChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 383,
+              "column": 8
+            },
+            "end": {
+              "line": 388,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "tableData"
+            }
+          ]
+        },
+        {
+          "name": "_remoteDataProviderChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 390,
+              "column": 8
+            },
+            "end": {
+              "line": 393,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "provider"
+            }
+          ]
+        },
+        {
+          "name": "_wrapDataProvider",
+          "description": "Wrap the supplied data provider in order to manipulate the request and data\nto work with our pagination state.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 399,
+              "column": 8
+            },
+            "end": {
+              "line": 420,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "provider"
+            }
+          ]
+        },
+        {
+          "name": "_localDataProvider",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 422,
+              "column": 8
+            },
+            "end": {
+              "line": 426,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "params"
+            },
+            {
+              "name": "callback"
+            }
+          ]
+        },
+        {
+          "name": "_localDataResolver",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 428,
+              "column": 8
+            },
+            "end": {
+              "line": 460,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "params"
+            },
+            {
+              "name": "items"
+            }
+          ]
+        },
+        {
+          "name": "_getAllLocalItems",
+          "description": "Will return all local items after filter (no ordering applied)",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 465,
+              "column": 8
+            },
+            "end": {
+              "line": 475,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onNavigationChange",
+          "description": "Listener for px-data-grid-navigation component",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 480,
+              "column": 8
+            },
+            "end": {
+              "line": 489,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ]
+        },
+        {
+          "name": "_onPageSizeChange",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 491,
+              "column": 8
+            },
+            "end": {
+              "line": 494,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "pageSize"
+            }
+          ]
+        },
+        {
+          "name": "_onPageChange",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 496,
+              "column": 8
+            },
+            "end": {
+              "line": 499,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "page"
+            }
+          ]
+        },
+        {
+          "name": "_updateGridData",
+          "description": "Update grid data via the current data provider.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 504,
+              "column": 8
+            },
+            "end": {
+              "line": 509,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_ensureValidPageNumber",
+          "description": "Checks if current page is smaller than the total number of pages\nand larger than 0.\nIf it is not valid, then reset it to 1.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 516,
+              "column": 8
+            },
+            "end": {
+              "line": 522,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_ensureValidPageSize",
+          "description": "Ensure page size is valid (greater than 0). If page size in invalid,\npage size will be set to 10.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 528,
+              "column": 8
+            },
+            "end": {
+              "line": 530,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_calcNumPages",
+          "description": "Calculates the number pages based on  total number of rows and the page size",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 535,
+              "column": 8
+            },
+            "end": {
+              "line": 541,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "numItems"
+            },
+            {
+              "name": "pageSize"
+            }
+          ]
+        },
+        {
+          "name": "_hidePageList",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 543,
+              "column": 8
+            },
+            "end": {
+              "line": 545,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "autoHidePageList"
+            },
+            {
+              "name": "size"
+            },
+            {
+              "name": "pageSize"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 51,
+          "column": 6
+        },
+        "end": {
+          "line": 546,
+          "column": 7
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "DataGridPaginatedElement",
+      "attributes": [
+        {
+          "name": "table-data",
+          "description": "Data for the table to display.\n\nExpected data format is a JSON array of objects. Each object in the array represents a row in the table.\n\nEach item in an object will be displayed as a separate column, unless px-data-table-columns are\ndefined to limit which columns are displayed.",
+          "sourceRange": {
+            "start": {
+              "line": 68,
+              "column": 12
+            },
+            "end": {
+              "line": 72,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "seletion-mode",
+          "description": "Current selection mode of grid. Accepts values 'none', 'single' and 'multi'.",
+          "sourceRange": {
+            "start": {
+              "line": 77,
+              "column": 12
+            },
+            "end": {
+              "line": 80,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "hide-selection-column",
+          "description": "If true, hides the column with checkboxes.",
+          "sourceRange": {
+            "start": {
+              "line": 85,
+              "column": 12
+            },
+            "end": {
+              "line": 88,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "selected-items",
+          "description": "An array that contains the selected items.",
+          "sourceRange": {
+            "start": {
+              "line": 93,
+              "column": 12
+            },
+            "end": {
+              "line": 97,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "size",
+          "description": "The total number of items",
+          "sourceRange": {
+            "start": {
+              "line": 102,
+              "column": 12
+            },
+            "end": {
+              "line": 106,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "page-size",
+          "description": "Number of items fetched at a time from the dataprovider.",
+          "sourceRange": {
+            "start": {
+              "line": 111,
+              "column": 12
+            },
+            "end": {
+              "line": 115,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "selectable-page-sizes",
+          "description": "Array of selectable page sizes offered to the user.",
+          "sourceRange": {
+            "start": {
+              "line": 120,
+              "column": 12
+            },
+            "end": {
+              "line": 123,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "page",
+          "description": "Current page number of displayed items. Page 1 should be the minimum value.",
+          "sourceRange": {
+            "start": {
+              "line": 128,
+              "column": 12
+            },
+            "end": {
+              "line": 132,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "multi-sort",
+          "description": "When `true`, user can sort by multiple columns",
+          "sourceRange": {
+            "start": {
+              "line": 137,
+              "column": 12
+            },
+            "end": {
+              "line": 140,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "active-item",
+          "description": "The item user has last interacted with. Turns to `null` after user deactivates\nthe item by re-interacting with the currently active item.",
+          "sourceRange": {
+            "start": {
+              "line": 146,
+              "column": 12
+            },
+            "end": {
+              "line": 150,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "resizable",
+          "description": "When `true`, user can resize columns",
+          "sourceRange": {
+            "start": {
+              "line": 155,
+              "column": 12
+            },
+            "end": {
+              "line": 158,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "column-reordering-allowed",
+          "description": "Set to true to allow column reordering.",
+          "sourceRange": {
+            "start": {
+              "line": 163,
+              "column": 12
+            },
+            "end": {
+              "line": 166,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "expanded-items",
+          "description": "An array containing references to expanded items.",
+          "sourceRange": {
+            "start": {
+              "line": 171,
+              "column": 12
+            },
+            "end": {
+              "line": 174,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "action-menu",
+          "description": "Define if table action menu is shown or not",
+          "sourceRange": {
+            "start": {
+              "line": 179,
+              "column": 12
+            },
+            "end": {
+              "line": 182,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "language",
+          "description": "A valid IETF language tag as a string that `app-localize-behavior` will\nuse to localize this component.\n\nSee https://github.com/PolymerElements/app-localize-behavior for API\ndocumentation and more information.",
+          "sourceRange": {
+            "start": {
+              "line": 218,
+              "column": 12
+            },
+            "end": {
+              "line": 221,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "use-key-if-missing",
+          "description": "Use the key for localization if value for that language is missing.\nShould always be true for Predix components.",
+          "sourceRange": {
+            "start": {
+              "line": 227,
+              "column": 12
+            },
+            "end": {
+              "line": 230,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "resources",
+          "description": "Library object of hardcoded strings used in this application.\nUsed by `app-localize-behavior` in conjunction with `language`.",
+          "sourceRange": {
+            "start": {
+              "line": 236,
+              "column": 12
+            },
+            "end": {
+              "line": 254,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "table-actions",
+          "description": "All custom table actions. Should return array of objects with 'name' (String) and 'action' (function).",
+          "sourceRange": {
+            "start": {
+              "line": 259,
+              "column": 12
+            },
+            "end": {
+              "line": 262,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "remote-data-provider",
+          "description": "Function that provides items lazily. Receives arguments params, callback",
+          "sourceRange": {
+            "start": {
+              "line": 267,
+              "column": 12
+            },
+            "end": {
+              "line": 270,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Function"
+        },
+        {
+          "name": "striped",
+          "description": "If true, every other row in the table will appear with a background color to improve visual scanning.",
+          "sourceRange": {
+            "start": {
+              "line": 279,
+              "column": 12
+            },
+            "end": {
+              "line": 282,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "loading-spinner-debounce",
+          "description": "How many milliseconds before loading spinner will be shown",
+          "sourceRange": {
+            "start": {
+              "line": 288,
+              "column": 12
+            },
+            "end": {
+              "line": 291,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "auto-filter",
+          "description": "To enable automatic filtering change property to true",
+          "sourceRange": {
+            "start": {
+              "line": 296,
+              "column": 12
+            },
+            "end": {
+              "line": 299,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "highlight",
+          "description": "Array of objects of conditions used to highlight specific columns.\nFormat:\n```javascript\n{\n  type: 'cell',\n  condition: (cellContent, column, item) => { return cellContent == 'John Doe' },\n},\n{\n  type: 'row',\n  condition: (cellContent, item) => { return cellContent[0] == 'a' },\n  color: '#a8a8a8'\n},\n{\n  type: 'column',\n  condition (column, item) => { return column.name == 'age' },\n  color: 'pink'\n}\n```",
+          "sourceRange": {
+            "start": {
+              "line": 321,
+              "column": 12
+            },
+            "end": {
+              "line": 324,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "default-column-width",
+          "description": "Default column width if not defined, eg. '100px'",
+          "sourceRange": {
+            "start": {
+              "line": 337,
+              "column": 12
+            },
+            "end": {
+              "line": 340,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "default-column-flex",
+          "description": "Default column flex if not defined, eg. 1",
+          "sourceRange": {
+            "start": {
+              "line": 345,
+              "column": 12
+            },
+            "end": {
+              "line": 348,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "grid-height",
+          "description": "Grid auto resize height to match number of rows.",
+          "sourceRange": {
+            "start": {
+              "line": 353,
+              "column": 12
+            },
+            "end": {
+              "line": 356,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "item-id-path",
+          "description": "Path to an item sub-property that identifies the item.",
+          "sourceRange": {
+            "start": {
+              "line": 361,
+              "column": 12
+            },
+            "end": {
+              "line": 364,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "auto-hide-page-list",
+          "description": "If true, automatically hides the page numbers list when there is only\n1 page available.",
+          "sourceRange": {
+            "start": {
+              "line": 370,
+              "column": 12
+            },
+            "end": {
+              "line": 373,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "table-data-changed",
+          "description": "Fired when the `tableData` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "selected-items-changed",
+          "description": "Fired when the `selectedItems` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "active-item-changed",
+          "description": "Fired when the `activeItem` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "px-data-grid-paginated"
+    }
+  ]
+}

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -115,6 +115,9 @@
               observer: '_onPageSizeChange'
             },
 
+            /**
+             * Array of selectable page sizes offered to the user.
+             */
             selectablePageSizes: {
               type: Array,
               value: [10, 20, 30]


### PR DESCRIPTION
Allows users to redefine the options offered. Fix paginated demo page (or element name and wrong API listing).

Fixes #357