### PR TITLE
Adding missing import for paginated grid (#373)

### DIFF
--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../vaadin-grid/vaadin-grid-selection-column.html">
 <link rel="import" href="../vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import" href="../px-spinner/px-spinner.html">
+<link rel="import" href="px-data-grid.html">
 <link rel="import" href="px-data-grid-column.html">
 <link rel="import" href="px-auto-filter-field.html">
 <link rel="import" href="px-data-grid-navigation.html">


### PR DESCRIPTION
Fixing #373

Was missing the px-data-grid.html import in the px-data-grid-paginated.html file.