### PR TITLE
Use new API in px-dropdown to offer unselectable options

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "iron-a11y-announcer": "^2.0.0",
     "iron-scroll-target-behavior": "^2.0.0",
     "px-icon-set": "^2.0.0",
-    "px-dropdown": "^4.0.0",
+    "px-dropdown": "^4.4.0",
     "vaadin-grid": "^4.1.0",
     "vaadin-radio-button": "1.0.0-alpha8",
     "px-spinner": "^2.2.0",

--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -6,7 +6,7 @@
 <dom-module id="px-data-grid-header-cell">
   <template>
     <style include="px-data-grid-header-cell-styles"></style>
-    <px-dropdown button-style="icon" icon="px-nav:menu" items="{{_dropdownItems}}" opened="{{dropdownOpened}}" hidden$="[[_dropdownHidden]]" on-selected-changed="_dropdownSelectedChanged">
+    <px-dropdown button-style="icon" icon="px-nav:menu" items="{{_dropdownItems}}" opened="{{dropdownOpened}}" hidden$="[[_dropdownHidden]]" on-px-dropdown-click="_dropdownClick">
       <px-icon slot="trigger" icon="px-nav:menu"></px-icon>
     </px-dropdown>
     <slot></slot>
@@ -145,7 +145,8 @@
                   key: {
                     action: () => this._unfreezeColumn()
                   },
-                  val: this.localize('Unfreeze column')
+                  val: this.localize('Unfreeze column'),
+                  disableSelect: true
                 }
               );
             } else {
@@ -154,7 +155,8 @@
                   key: {
                     action: () => this._freezeColumn()
                   },
-                  val: this.localize('Freeze column')
+                  val: this.localize('Freeze column'),
+                  disableSelect: true
                 }
               );
             }
@@ -164,7 +166,8 @@
                 key: {
                   action: () => this._hideColumn()
                 },
-                val: this.localize('Hide column')
+                val: this.localize('Hide column'),
+                disableSelect: true
               }
             );
 
@@ -175,7 +178,8 @@
                     key: {
                       action: () => this._ungroup()
                     },
-                    val: this.localize('Ungroup')
+                    val: this.localize('Ungroup'),
+                    disableSelect: true
                   }
                 );
               } else {
@@ -184,7 +188,8 @@
                     key: {
                       action: () => this._groupByColumn()
                     },
-                    val: this.localize('Group by column')
+                    val: this.localize('Group by column'),
+                    disableSelect: true
                   }
                 );
               }
@@ -210,10 +215,11 @@
           }
         }
 
-        _dropdownSelectedChanged(e) {
-          if (e.detail.value) {
-            e.detail.value.action();
-            e.target.selected = null;
+        _dropdownClick(e) {
+          const item = e.detail.detail.item;
+
+          if (item && item.key) {
+            item.key.action();
           }
         }
 

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1009,7 +1009,7 @@
                 key: '-action-' + item.id,
                 val: item.name,
                 selected: false,
-                disabled: true
+                disableSelect: true
               });
             });
           }
@@ -1019,7 +1019,7 @@
               key: '-internal-ungroup-',
               val: this.localize('Clear Grouping'),
               selected: false,
-              disabled: true
+              disableSelect: true
             });
           }
 


### PR DESCRIPTION
Fixes #417

Also in headers does not need to unselect selections, and can just
use the click listener directly.