### PR TITLE
Add table actions to paginated version of px-data-grid

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -132,10 +132,10 @@
     exportToCsv: function() {
       const grid = this.shadowRoot.querySelector('px-data-grid');
       const data = grid.getData();
-      const columns = grid._getVisibleColumns();
+      const columns = grid.getVisibleColumns();
       let csvContent = 'data:text/csv;charset=utf-8,';
 
-      csvContent += columns.map((column) => grid._resolveColumnHeader(column)).join(',') + '\r\n';
+      csvContent += columns.map((column) => grid.resolveColumnHeader(column)).join(',') + '\r\n';
       data.forEach((item) => {
         csvContent += Object.keys(item).map((key) => item[key]).join(',') + '\r\n';
       });

--- a/demo/px-data-grid-paginated-demo.html
+++ b/demo/px-data-grid-paginated-demo.html
@@ -67,7 +67,9 @@
             on-cell-unhover="cellUnhoverListener"
             selectable-page-sizes="{{props.selectablePageSizes.value}}"
             columns="{{props.columns.value}}"
-            grid-height="{{props.gridHeight.value}}">
+            grid-height="{{props.gridHeight.value}}"
+            table-actions="{{props.tableActions.value}}"
+            on-table-action="tableActionListener">
         </px-data-grid-paginated>
 
         <dom-if if="[[selectedItems.length]]">
@@ -528,6 +530,18 @@
           }
         ],
         inputType: 'code:JSON'
+      },
+
+      tableActions: {
+        type: Object,
+        defaultValue: [
+          {
+            name: 'Export CSV',
+            id: 'CSV'
+          }
+        ],
+        inputType: 'code:JSON',
+        _visibleForConfig: false
       }
     },
 
@@ -554,6 +568,32 @@
 
     _clearColumns(event) {
       this.props.columns.value = this._getDefaultColumns();
+    },
+
+    tableActionListener: function(evt) {
+      if (evt.detail.id === 'CSV') {
+        this.exportToCsv();
+      }
+    },
+
+    exportToCsv: function() {
+      const grid = this.shadowRoot.querySelector('px-data-grid-paginated');
+      const data = grid.getData();
+      const columns = grid.getVisibleColumns();
+      let csvContent = 'data:text/csv;charset=utf-8,';
+
+      csvContent += columns.map((column) => grid.resolveColumnHeader(column)).join(',') + '\r\n';
+      data.forEach((item) => {
+        csvContent += Object.keys(item).map((key) => item[key]).join(',') + '\r\n';
+      });
+
+      const encodedUri = encodeURI(csvContent);
+      const link = document.createElement('a');
+      link.setAttribute('href', encodedUri);
+      link.setAttribute('download', 'table_data.csv');
+      document.body.appendChild(link);
+
+      link.click();
     }
   });
 </script>

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -33,7 +33,9 @@
       language="{{language}}"
       auto-filter="{{autoFilter}}"
       grid-height="{{gridHeight}}"
-      item-id-path="{{itemIdPath}}">
+      item-id-path="{{itemIdPath}}"
+      table-actions="{{tableActions}}"
+      on-table-action="_tableActionListener">
     </px-data-grid>
 
     <px-data-grid-navigation
@@ -260,7 +262,6 @@
              */
             tableActions: {
               type: Array,
-              value: []
             },
 
             /**
@@ -561,6 +562,37 @@
 
         _hidePageList(autoHidePageList, size, pageSize) {
           return autoHidePageList && this._calcNumPages(size, pageSize) === 1;
+        }
+
+        // Reemit event from px-data-grid
+        _tableActionListener(event) {
+          this.dispatchEvent(new CustomEvent('table-action', {
+            detail: {
+              id: event.detail.id
+            },
+            bubbles: true
+          }));
+        }
+
+        /**
+         * Get data current shown on grid
+         */
+        getData(visibleOnly) {
+          return this._pxDataGrid.getData(visibleOnly);
+        }
+
+        /**
+         * Get current visible columns in grid
+         */
+        getVisibleColumns() {
+          return this._pxDataGrid.getVisibleColumns();
+        }
+
+        /**
+         * Helper method to check if header is defined, if not use name
+         */
+        resolveColumnHeader(column) {
+          return this._pxDataGrid.resolveColumnHeader(column);
         }
       }
       customElements.define(DataGridPaginatedElement.is, DataGridPaginatedElement);

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -101,7 +101,7 @@
           is-remote-data-provider="[[!_hasLocalDataProvider]]"
           is-data-column="true">
           <template class="header">
-            <px-data-grid-sorter path="[[_resolveColumnPath(column)]]">[[_resolveColumnHeader(column)]]</px-data-grid-sorter>
+            <px-data-grid-sorter path="[[_resolveColumnPath(column)]]">[[resolveColumnHeader(column)]]</px-data-grid-sorter>
           </template>
 
           <template>
@@ -1083,7 +1083,7 @@
         /**
          * Helper method to check if header is defined, if not use name
          */
-        _resolveColumnHeader(column) {
+        resolveColumnHeader(column) {
           return column.header ? column.header : column.name;
         }
 
@@ -1359,7 +1359,10 @@
             .map((col) => col.mappedObject);
         }
 
-        _getVisibleColumns() {
+        /**
+         * Get current visible columns in grid
+         */
+        getVisibleColumns() {
           return this._vaadinGrid
             ._columnTree[this._vaadinGrid._columnTree.length - 1]
             .slice(0)
@@ -1400,7 +1403,7 @@
           return items.map((item) => {
             const sortedObject = {};
 
-            this._getVisibleColumns().forEach((col) => {
+            this.getVisibleColumns().forEach((col) => {
               sortedObject[col.path] = item[col.path];
             });
 


### PR DESCRIPTION
Fixes #416

Also remove _ prefix from functions that are required to generate
CSV export in demo. And add matching functions to paginated
version that will pass the call to grid inside. Also pass table
action event from px-data-grid to users of px-data-grid-paginated.
All this boiler plate might become useful in the future, as
behavior of these functions and events might change in paginated
version. Also getData will now just return all shown data, not
all data. I assume this is correct for paginated version.