### PR TITLE
Fix wildcard regex generation and save filters

### DIFF
--- a/demo/px-data-grid-demo.html
+++ b/demo/px-data-grid-demo.html
@@ -71,7 +71,9 @@
             on-cell-hover="cellHoverListener"
             on-cell-unhover="cellUnhoverListener"
             grid-height="{{props.gridHeight.value}}"
-            on-table-action="tableActionListener">
+            offer-filter-saving="{{props.offerFilterSaving.value}}"
+            on-table-action="tableActionListener"
+            on-save-filters="saveFilterListener">
         </px-data-grid>
 
         <div class="button-row">
@@ -153,6 +155,10 @@
       if (evt.detail.id === 'CSV') {
         this.exportToCsv();
       }
+    },
+
+    saveFilterListener: function(evt) {
+      window.alert('Filters should be saved now');
     },
 
     properties: {
@@ -582,6 +588,12 @@
         ],
         inputType: 'code:JSON',
         _visibleForConfig: false
+      },
+
+      offerFilterSaving: {
+        type: Boolean,
+        defaultValue: false,
+        inputType: 'toggle'
       }
     },
 

--- a/px-data-grid-filter.html
+++ b/px-data-grid-filter.html
@@ -11,8 +11,10 @@
       <px-data-grid-filter-section section="{{section}}" columns="[[columns]]" localize="[[localize]]"></px-data-grid-filter-section>
     </template>
 
-    <input id="saveFilterSet" type="checkbox">
-    <label class="label--inline" for="saveFilterSet">[[localize('Save this filter set')]]</label>
+    <template is="dom-if" if="[[offerFilterSaving]]" restamp>
+      <input id="saveFilterSet" type="checkbox">
+      <label class="label--inline" for="saveFilterSet">[[localize('Save this filter set')]]</label>
+    </template>
 
     <!--
     <button class="btn btn--bare--primary" on-click="_addGroup">
@@ -42,6 +44,11 @@
               notify: true
             },
 
+            offerFilterSaving: {
+              type: Boolean,
+              notify: false
+            },
+
             _tempFilters: {
               type: Array
             },
@@ -69,11 +76,14 @@
         }
 
         applyFilters() {
-          this.filters = this._tempFilters;
 
-          if (this.$.saveFilterSet.checked) {
+          const checkbox = this.shadowRoot.querySelector('#saveFilterSet');
+
+          if (checkbox && checkbox.checked) {
+            this.filters = this._tempFilters;
+
             this.dispatchEvent(
-              new CustomEvent('filters-changed',
+              new CustomEvent('save-filters',
                 {
                   bubbles: true,
                   composed: true,

--- a/px-data-grid-filterable-mixin.html
+++ b/px-data-grid-filterable-mixin.html
@@ -85,7 +85,7 @@
           regex = new RegExp(`${this._escapeRegExp(filter.query)}$`, 'i');
           break;
         case 'wildcard':
-          if(filter.query === undefined || filter.query === '*') {
+          if (!filter.query || filter.query === '*') {
             regex = new RegExp('.*', 'i');
           } else {
             regex = new RegExp(`^${filter.query.split('*').map(this._escapeRegExp).join('.*')}$`, 'i');

--- a/px-data-grid-filterable-mixin.html
+++ b/px-data-grid-filterable-mixin.html
@@ -85,7 +85,11 @@
           regex = new RegExp(`${this._escapeRegExp(filter.query)}$`, 'i');
           break;
         case 'wildcard':
-          regex = new RegExp(`${filter.query.split('*').map(this._escapeRegExp).join('.*')}`, 'i');
+          if(filter.query === undefined || filter.query === '*') {
+            regex = new RegExp('.*', 'i');
+          } else {
+            regex = new RegExp(`^${filter.query.split('*').map(this._escapeRegExp).join('.*')}$`, 'i');
+          }
           break;
       }
 

--- a/px-data-grid-filters-modal.html
+++ b/px-data-grid-filters-modal.html
@@ -14,7 +14,13 @@
       header-text="[[localize('Filter Columns')]]"
       open-trigger="[[filtersModalTrigger]]">
       <div slot="body">
-        <px-data-grid-filter id="filters" columns="[[columns]]" filters="{{filters}}" localize="[[localize]]"></px-data-grid-filter>
+        <px-data-grid-filter
+          id="filters"
+          columns="[[columns]]"
+          filters="{{filters}}"
+          offer-filter-saving="[[offerFilterSaving]]"
+          localize="[[localize]]">
+        </px-data-grid-filter>
 
         <div class="filter-modal-buttons-container">
           <button class="btn" on-click="_reset">[[localize('Reset')]]</button>
@@ -57,6 +63,11 @@
 
             initialFilterState: {
               type: Array,
+            },
+
+            offerFilterSaving: {
+              type: Boolean,
+              value: false
             },
 
             localize: Function

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -586,6 +586,8 @@
 
         // Reemit event from px-data-grid
         _saveFiltersListener(event) {
+          event.stopPropagation();
+
           this.dispatchEvent(new CustomEvent('save-filters', {
             detail: {
               filters: event.detail.filters

--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -35,7 +35,9 @@
       grid-height="{{gridHeight}}"
       item-id-path="{{itemIdPath}}"
       table-actions="{{tableActions}}"
-      on-table-action="_tableActionListener">
+      offer-filter-saving="{{offerFilterSaving}}"
+      on-table-action="_tableActionListener"
+      on-save-filters="_saveFiltersListener">
     </px-data-grid>
 
     <px-data-grid-navigation
@@ -373,6 +375,14 @@
             autoHidePageList: {
               type: Boolean,
               value: true
+            },
+
+            /**
+             * If filter saving options should offered to end user. If save is
+             * selected it will emit save-filters event.
+             */
+            offerFilterSaving: {
+              type: Boolean
             }
 
           };
@@ -569,6 +579,16 @@
           this.dispatchEvent(new CustomEvent('table-action', {
             detail: {
               id: event.detail.id
+            },
+            bubbles: true
+          }));
+        }
+
+        // Reemit event from px-data-grid
+        _saveFiltersListener(event) {
+          this.dispatchEvent(new CustomEvent('save-filters', {
+            detail: {
+              filters: event.detail.filters
             },
             bubbles: true
           }));

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -44,7 +44,13 @@
 
         <div class="action-bar__right">
           <template is="dom-if" if="[[filterable]]">
-            <px-data-grid-filters-modal filters="{{_filters}}" columns="[[columns]]" localize="[[_boundedLocalize]]" initial-filter-state="[[_initialFilterState]]"></px-data-grid-filters-modal>
+            <px-data-grid-filters-modal
+              filters="{{_filters}}"
+              columns="[[columns]]"
+              localize="[[_boundedLocalize]]"
+              offer-filter-saving="[[offerFilterSaving]]"
+              initial-filter-state="[[_initialFilterState]]">
+            </px-data-grid-filters-modal>
           </template>
 
           <template is="dom-if" if="[[!hideActionMenu]]">
@@ -586,6 +592,15 @@
             itemIdPath: {
               type: String,
               value: null
+            },
+
+            /**
+             * If filter saving options should offered to end user. If save is
+             * selected it will emit save-filters event.
+             */
+            offerFilterSaving: {
+              type: Boolean,
+              value: false
             },
 
             /**

--- a/test/filterable.js
+++ b/test/filterable.js
@@ -28,8 +28,34 @@ document.addEventListener('WebComponentsReady', () => {
       expect(grid._isStringMatches({pattern: 'ends_with', query: 'eth'}, 'Elizabeth')).to.be.true;
       expect(grid._isStringMatches({pattern: 'ends_with', query: 'ath'}, 'Elizabeth')).to.be.false;
 
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*'}, 'Elizabeth')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: 'E*'}, 'Elizabeth')).to.be.true;
       expect(grid._isStringMatches({pattern: 'wildcard', query: 'E*th'}, 'Elizabeth')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*th'}, 'Elizabeth')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: 'a*'}, 'Elizabeth')).to.be.false;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: 'be*'}, 'Elizabeth')).to.be.false;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: 'Be*'}, 'Elizabeth')).to.be.false;
       expect(grid._isStringMatches({pattern: 'wildcard', query: 'P*th'}, 'Elizabeth')).to.be.false;
+
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '+*'}, '+foo+')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '+*+'}, '+foo+')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*foo*'}, '+foo+')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*foo*'}, 'foo')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*foo*'}, '+')).to.be.false;
+
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '/*'}, '/test')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '{*'}, '{test')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*}'}, 'test}')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '(*)'}, '(test)')).to.be.true;
+
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*/'}, '/test')).to.be.false;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*{'}, '{test')).to.be.false;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '}*'}, 'test}')).to.be.false;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*()*'}, '(test)')).to.be.false;
+
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '+*'}, '+foo+')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '+*+'}, '+foo+')).to.be.true;
+      expect(grid._isStringMatches({pattern: 'wildcard', query: '*foo*'}, '+foo+')).to.be.true;
     });
 
     it('should check date properly', () => {


### PR DESCRIPTION
Wildcard -> regex were missing ^ and $ from the rule. Also improved the undefined, empty and * cases. And wrote more tests.

Also improves save filters checkbox action, it's now optional. As not all application want to save filters.

Fixes #512