### PR TITLE
Fix keyboard a11y for editable cells inputs

### DIFF
--- a/px-data-grid-cell-content-wrapper.html
+++ b/px-data-grid-cell-content-wrapper.html
@@ -74,6 +74,13 @@
           });
         }
 
+        focus() {
+          const input = this._valueElement.shadowRoot.querySelector('#editingTemplateInput');
+          if (input && input.focus) {
+            input.focus();
+          }
+        }
+
         _fireCellHoverEvent(event) {
           this.dispatchEvent(
             new CustomEvent('cell-hover', {

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -131,7 +131,12 @@
                       <px-icon icon="px-utl:chevron"></px-icon>
                     </template>
                   </template>
-                  <px-data-grid-cell-content-wrapper cell-color="[[_resolveCellColor(item, column, _highlightEntities.*)]]" item="{{item}}" column="[[column]]" localize="[[_boundedLocalize]]">
+                  <px-data-grid-cell-content-wrapper
+                    focus-target
+                    cell-color="[[_resolveCellColor(item, column, _highlightEntities.*)]]"
+                    item="{{item}}"
+                    column="[[column]]"
+                    localize="[[_boundedLocalize]]">
                   </px-data-grid-cell-content-wrapper>
                 </vaadin-grid-tree-toggle>
               </template>
@@ -139,7 +144,12 @@
 
             <dom-if if="[[!_isGroupedByColumn(column, _groupByColumn)]]">
               <template>
-                <px-data-grid-cell-content-wrapper cell-color="[[_resolveCellColor(item, column, _highlightEntities.*, _editingItem)]]" item="{{item}}" column="[[column]]" localize="[[_boundedLocalize]]">
+                <px-data-grid-cell-content-wrapper
+                  focus-target
+                  cell-color="[[_resolveCellColor(item, column, _highlightEntities.*, _editingItem)]]"
+                  item="{{item}}"
+                  column="[[column]]"
+                  localize="[[_boundedLocalize]]">
                 </px-data-grid-cell-content-wrapper>
               </template>
             </dom-if>


### PR DESCRIPTION
Connected to https://github.com/vaadin/px-data-grid/issues/474

This change fixes the focusing of `string` and `number` renderers. The `date` still doesn't work because of `px-datetime-picker` doesn't implement `.focus()` method on itself. 

I reported that issue to them: https://github.com/PredixDev/px-datetime-picker/issues/30