### PR TITLE
Make advanced filter use slots of px-modal

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "px-spinner": "^2.2.0",
     "px-tooltip": "^1.2.3",
     "px-datetime-picker": "^2.0.2",
-    "px-modal": "^3.0.1",
+    "px-modal": "^3.2.0",
     "px-buttons-design": "^2.0.6",
     "px-chip": "^1.1.0",
     "px-actionable-design": "^2.0.5",

--- a/px-data-grid-filter.html
+++ b/px-data-grid-filter.html
@@ -85,7 +85,7 @@
         }
 
         resetFilters() {
-          this.set('filters' [{entities: [{}], action: 'show', operationType: 'all'}]);
+          this.set('filters', [{entities: [{}], action: 'show', operationType: 'all'}]);
         }
 
         _restoreTempFilters() {

--- a/px-data-grid-filters-modal.html
+++ b/px-data-grid-filters-modal.html
@@ -33,7 +33,7 @@
           <button class="btn" on-click="_reset">[[localize('Reset')]]</button>
         </template>
       </div>
-      <button slot="reject-trigger" on-click="_cancel">[[localize('Cancel')]]</button>
+      <button slot="reject-trigger" class="btn" on-click="_cancel">[[localize('Cancel')]]</button>
       <button slot="accept-trigger" class="btn btn--call-to-action" on-click="_apply">[[localize('Apply')]]</button>
     </px-modal>
 

--- a/px-data-grid-filters-modal.html
+++ b/px-data-grid-filters-modal.html
@@ -27,19 +27,14 @@
           <input id="saveFilterSet" type="checkbox">
           <label class="label--inline" for="saveFilterSet">[[localize('Save this filter set')]]</label>
         </template>
-
-        <div class="filter-modal-buttons-container">
-          <template is="dom-if" if="[[_hasAnyEntity(_tempFilters, _tempFilters.*)]]">
-            <button class="btn" on-click="_reset">[[localize('Reset')]]</button>
-          </template>
-          <div class="filter-modal-buttons-container__right">
-            <button class="btn" on-click="_cancel">[[localize('Cancel')]]</button>
-            <button class="btn btn--call-to-action" on-click="_apply">[[localize('Apply')]]</button>
-          </div>
-        </div>
       </div>
-      <div slot="reject-trigger"></div>
-      <div slot="accept-trigger"></div>
+      <div slot="actions" class="action-buttons">
+        <template is="dom-if" if="[[_hasAnyEntity(_tempFilters, _tempFilters.*)]]">
+          <button class="btn" on-click="_reset">[[localize('Reset')]]</button>
+        </template>
+      </div>
+      <button slot="reject-trigger" on-click="_cancel">[[localize('Cancel')]]</button>
+      <button slot="accept-trigger" class="btn btn--call-to-action" on-click="_apply">[[localize('Apply')]]</button>
     </px-modal>
 
     <px-modal-trigger trigger="{{filtersModalTrigger}}">

--- a/sass/px-data-grid-filters-modal.scss
+++ b/sass/px-data-grid-filters-modal.scss
@@ -1,14 +1,7 @@
 @import 'px-data-grid-shared';
 
-.filter-modal-buttons-container {
-  padding: $inuit-base-spacing-unit--large;
-  padding-bottom: 0;
-  margin-bottom: calc(0px - #{$inuit-base-spacing-unit--large});
-  display: flex;
-}
-
-.filter-modal-buttons-container__right {
-  margin-left: auto;
+.action-buttons {
+  width: 100%;
 }
 
 input[type="checkbox"] {


### PR DESCRIPTION
Use new px-modal that allows to inject all 3 buttons in. Doesn't yet fix the sizing issues when window is resized anyhow. But will make buttons clickable on all browsers (earlier the unused slots overlapped buttons, now buttons are in slots).

Related to #363 
