### PR TITLE
Enabled smartOrientation on px-tooltips

### DIFF
--- a/px-data-grid-filters-preview.html
+++ b/px-data-grid-filters-preview.html
@@ -17,6 +17,7 @@
             <px-tooltip
               for="chip-[[index]]"
               orientation="top"
+              smartOrientation
               tooltip-message="[[_getTooltipMessage(entity, section, filters.*, localize)]]">
             </px-tooltip>
             <px-chip


### PR DESCRIPTION
However, doesn't work on px-demo but should work on non demo-apps. Checked with GE devs that this is a known issue on px-tooltip relating to overflows.

Fixes #521 