### PR TITLE
Improve documentation of defaultColumn Width and FlexGrow

### DIFF
--- a/px-data-grid-paginated.html
+++ b/px-data-grid-paginated.html
@@ -37,7 +37,9 @@
       table-actions="{{tableActions}}"
       offer-filter-saving="{{offerFilterSaving}}"
       filterable="{{filterable}}"
-      editable="{{editable}}">
+      editable="{{editable}}"
+      default-column-width="{{defaultColumnWidth}}"
+      default-column-flex-grow="{{defaultColumnFlexGrow}}">
     </px-data-grid>
 
     <px-data-grid-navigation
@@ -317,19 +319,20 @@
             },
 
             /**
-             * Default column width if not defined, eg. '100px'
+             * Default column width if not defined, eg. '100px'. Notice that with not
+             * zero flex values this value behaves more as minimum width. See
+             * defaultColumnFlexGrow property.
              */
             defaultColumnWidth: {
-              type: String,
-              value: '100px'
+              type: String
             },
 
             /**
-             * Default column flex if not defined, eg. 1
+             * Default column flex if not defined, eg. 1. Equialent to the CSS flex-grow
+             * property.
              */
-            defaultColumnFlex: {
-              type: Number,
-              value: 1
+            defaultColumnFlexGrow: {
+              type: Number
             },
 
             /**

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -587,7 +587,9 @@
             },
 
             /**
-             * Default column width if not defined, eg. '100px'
+             * Default column width if not defined, eg. '100px'. Notice that with not
+             * zero flex values this value behaves more as minimum width. See
+             * defaultColumnFlexGrow property.
              */
             defaultColumnWidth: {
               type: String,
@@ -595,9 +597,10 @@
             },
 
             /**
-             * Default column flex if not defined, eg. 1
+             * Default column flex if not defined, eg. 1. Equialent to the CSS flex-grow
+             * property.
              */
-            defaultColumnFlex: {
+            defaultColumnFlexGrow: {
               type: Number,
               value: 1
             },
@@ -876,7 +879,7 @@
         }
 
         _getColumnFlexGrow(column) {
-          return column.flexGrow === undefined ? this.defaultColumnFlex : column.flexGrow;
+          return column.flexGrow === undefined ? this.defaultColumnFlexGrow : column.flexGrow;
         }
 
         _resolveCellColor(item, column) {


### PR DESCRIPTION
API change, renamed defaultColumnFlex to defaultColumnFlexGrow.
Added missing mapping of these values from px-data-grid-paginated\
to px-data-grid.

Fixes #530