### PR TITLE
Do not allow hiding if last visible column

### DIFF
--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -169,15 +169,17 @@
               );
             }
 
-            newItems.push(
-              {
-                key: {
-                  action: () => this._hideColumn()
-                },
-                val: this.localize('Hide column'),
-                disableSelect: true
-              }
-            );
+            if (this._canBeHidden()) {
+              newItems.push(
+                {
+                  key: {
+                    action: () => this._hideColumn()
+                  },
+                  val: this.localize('Hide column'),
+                  disableSelect: true
+                }
+              );
+            }
 
             if (this.groupByColumnAllowed) {
               if (this._column.grouped) {
@@ -239,6 +241,15 @@
         _dropdownClick(e) {
           e.stopPropagation();
           e.preventDefault();
+        }
+
+        _canBeHidden() {
+          if (this._column && this._column._grid && this._column._grid._pxDataGrid) {
+            return this._column._grid._pxDataGrid.getVisibleColumns().length > 1;
+          } else {
+            console.warn('Failed to resolve if column can be hidden');
+            return true;
+          }
         }
       }
 

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -1212,6 +1212,7 @@
           const defaultName = this.localize('Column #');
           let counter = 0;
           const selected = [];
+          const disableSelected = this.getVisibleColumns().length <= 1;
 
           this._getColumns().forEach((columnElement) => {
             const index = ++counter;
@@ -1222,7 +1223,8 @@
 
             const item = {
               key: key,
-              val: name
+              val: name,
+              disabled: disableSelected && !hidden
             };
 
             if (!hidden) {
@@ -1566,12 +1568,17 @@
          * Get current visible columns in grid
          */
         getVisibleColumns() {
+          // Do not break if called too early
+          if (this._vaadinGrid == undefined || this._vaadinGrid._columnTree === undefined) {
+            return [];
+          }
+
           return this._vaadinGrid
             ._columnTree[this._vaadinGrid._columnTree.length - 1]
             .slice(0)
             .sort((a, b) => a._order - b._order)
             .map((col) => col.mappedObject)
-            .filter((col) => !col.hidden);
+            .filter((col) => col !== undefined && !col.hidden);
         }
 
         /**


### PR DESCRIPTION
Prevents hiding from table actions and column menus if last visible column. Also do not throw exception if getVisibleColumns called too early, just return empty array.

Fixes #421