### PR TITLE
Fix double scroll bars in advanced filtering modal

### DIFF
--- a/sass/px-data-grid-filter.scss
+++ b/sass/px-data-grid-filter.scss
@@ -1,8 +1,6 @@
 @import 'px-data-grid-shared';
 
 :host {
-  overflow: auto;
-  max-height: 80vh;
   max-width: 100%;
   display: block;
   padding: 0 $inuit-base-spacing-unit--large;


### PR DESCRIPTION
We updated the px-modal to handle overflowing content in the "body" slot by scrolling the entire modal. This is different from the spec where the header/footer of the modal are fixed and only the body scrolls. The GE designers have accepted and said this approach is OK for now.

This PR fixes a collision of the two approaches. Before to make the modal work correctly the px-data-grid-filter component created its own scrolling region if its contents were too tall. This leads to a double scroll bar:

![image](https://user-images.githubusercontent.com/6456757/35886770-0316d0ca-0b47-11e8-98b9-9d34c29c6543.png)

I took the overflow scroll behavior out of px-data-grid-filter, so the modal can decide how its contents should scroll. This is the result:

![image](https://user-images.githubusercontent.com/6456757/35886825-349b3140-0b47-11e8-98f1-13152ab9c9ee.png)
