### PR TITLE
Add allow-outside-scroll to all px-dropdowns

### DIFF
--- a/px-data-grid-action-column.html
+++ b/px-data-grid-action-column.html
@@ -21,6 +21,7 @@
       </template>
       <template is="dom-if" if="[[_showActionDropdown(item, editMode, edittedItem)]]" restamp>
         <px-dropdown
+            allow-outside-scroll
             button-style="icon"
             icon="px-nav:menu"
             items="[[_convertActions(itemActions)]]"

--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -14,6 +14,7 @@
       </label>
       <px-dropdown
         id="column-dropdown"
+        allow-outside-scroll
         items="[[_mappedColumns]]"
         disable-clear
         selected="{{entity.columnId}}">
@@ -27,6 +28,7 @@
         </label>
         <px-dropdown
           id="condition-dropdown"
+          allow-outside-scroll
           items="[[_regexPatterns]]"
           disable-clear
           selected="{{entity.pattern}}">
@@ -66,6 +68,7 @@
           </label>
           <px-dropdown
             id="number-condition-dropdown"
+            allow-outside-scroll
             items="[[_numberConditions]]"
             disable-clear
             selected="{{entity.condition}}">

--- a/px-data-grid-filter-section.html
+++ b/px-data-grid-filter-section.html
@@ -11,6 +11,7 @@
     <template is="dom-if" if="[[_hasAnyEntity(section, section.*)]]">
       <div class="action-select">
         <px-dropdown
+          allow-outside-scroll
           items='[[_actions]]'
           button-style="bare--primary"
           disable-clear
@@ -18,6 +19,7 @@
         </px-dropdown>
         <span>[[localize('items that match')]]</span>
         <px-dropdown
+          allow-outside-scroll
           items='[[_operationTypes]]'
           button-style="bare--primary"
           disable-clear

--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -7,6 +7,7 @@
   <template>
     <style include="px-data-grid-header-cell-styles"></style>
     <px-dropdown
+        allow-outside-scroll
         button-style="icon"
         icon="px-nav:menu"
         items="{{_dropdownItems}}"

--- a/px-data-grid-navigation.html
+++ b/px-data-grid-navigation.html
@@ -13,6 +13,7 @@
     <div class="page-size-select">
       [[localize('Rows per page')]]
       <px-dropdown
+        allow-outside-scroll
         display-value="[[_numToStr(pageSize)]]"
         items="[[_numArrayToStrArray(selectablePageSizes)]]"
         on-selected-changed="_pageSizeChange"

--- a/px-data-grid.html
+++ b/px-data-grid.html
@@ -57,7 +57,10 @@
           </template>
 
           <template is="dom-if" if="[[!hideActionMenu]]">
-            <px-dropdown multi hide-selected
+            <px-dropdown
+              multi
+              hide-selected
+              allow-outside-scroll
               display-value="[[localize('Actions')]]"
               items="[[_actionMenuContent]]"
               selected-values="[[_selectedActionItems]]"


### PR DESCRIPTION
Connected to https://github.com/PolymerElements/iron-overlay-behavior/pull/263

Currently any `px-dropdown` will disable scrolling of the whole document, IMO that's unwanted and `px-dropdown` should refit in viewport instead of blocking it.