### PR TITLE
Add display formatting for number renderer

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -30,7 +30,8 @@
     "px-popover": "^2.1.2",
     "px-slider": "^2.1.1",
     "px-rangepicker": "^3.2.0",
-    "px-moment-imports": "^1.0.0"
+    "px-moment-imports": "^1.0.0",
+    "px-number-formatter": "^4.2.0"
   },
   "devDependencies": {
     "px-theme": "^3.1.4",

--- a/examples/renderer-number-config.html
+++ b/examples/renderer-number-config.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Number Renderer Configurations | px-data-grid examples</title>
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../../polymer/polymer.html"/>
+  <link rel="import" href="../../px-theme/px-theme-styles.html"/>
+  <link rel="import" href="../css/px-data-grid-light-theme-styles.html"/>
+  <link rel="import" href="../px-data-grid.html"/>
+
+  <style>
+    html, body {
+      font-size: 15px;
+      margin: 0;
+      padding: 0;
+    }
+  </style>
+</head>
+<body>
+  <custom-style>
+    <style is="custom-style" include="px-theme-styles"></style>
+  </custom-style>
+  <custom-style>
+    <style include="px-data-grid-light-theme-styles"></style>
+  </custom-style>
+
+  <px-data-grid editable></px-data-grid>
+
+  <script>
+    const grid = document.querySelector('px-data-grid');
+
+    grid.columns = [
+      {
+        name: 'Name',
+        path: 'name'
+      },
+      // Height column is rendered without any formatting
+      {
+        name: 'Height',
+        path: 'height',
+        renderer: 'px-data-grid-number-renderer',
+        editable: true
+      },
+      // Weight column is formatted to use commas and strip decimals
+      {
+        name: 'Weight',
+        path: 'weight',
+        renderer: 'px-data-grid-number-renderer',
+        editable: true,
+        rendererConfig: {
+          displayFormat: '0,0'
+        }
+      },
+      // Model column contains data formatted as a number but stored as a string
+      // Some of the data can be parsed to a number, but some data can't be
+      // parsed. Check the console to see errors for non-numeric values.
+      {
+        name: 'Model',
+        path: 'model',
+        renderer: 'px-data-grid-number-renderer',
+        editable: true
+      }
+    ];
+
+    grid.tableData = [
+      {
+        name: 'GENERATOR 001',
+        height: 60.224,
+        weight: 190378.487,
+        model: '1934'
+      },
+      {
+        name: 'GENERATOR 002',
+        height: -63.13,
+        weight: 238712.03,
+        model: '1934.29'
+      },
+      {
+        name: 'GENERATOR 003',
+        height: 59.49,
+        weight: 0,
+        model: '099A'
+      },
+      {
+        name: 'GENERATOR 004',
+        height: 68,
+        weight: 478209.22,
+        model: ''
+       }
+    ];
+  </script>
+</body>
+</html>

--- a/px-data-grid-number-renderer.html
+++ b/px-data-grid-number-renderer.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer-element.html">
 <link rel="import" href="../px-tooltip/px-tooltip.html">
+<link rel="import" href="../px-number-formatter/px-number-formatter-no-display.html">
 <link rel="import" href="px-data-grid-renderer-mixin.html">
 <link rel="import" href="px-data-grid-theme.html">
 <link rel="import" href="css/px-data-grid-number-renderer-styles.html">
@@ -31,12 +32,20 @@ Make number-renderer columns use ellipsis overflow:
 <dom-module id="px-data-grid-number-renderer">
   <template>
     <style include="px-data-grid-number-renderer-styles"></style>
-    <template is="dom-if" if="[[!_editing]]">[[_getFormattedNumber(value)]]</template>
+    <px-number-formatter-no-display
+        value="[[value]]"
+        format="[[_getDisplayFormat(displayFormat)]]"
+        currency="[[displayIsCurrency]]"
+        culture="[[displayCulture]]"
+        zero-format="[[displayZeroFormat]]"
+        formatted-value="{{_formattedValue}}">
+    </px-number-formatter-no-display>
+    <template is="dom-if" if="[[!_editing]]">[[_formattedValue]]</template>
     <template is="dom-if" if="[[_editing]]" restamp>
       <div id="editingTemplate" class="input-container">
 
         <!-- In IE11 input[type=number] does not work properly. -->
-        <input id="editingTemplateInput" class$="{{getClasses(validationResult)}}" type$="[[_getInputFieldType(_ie)]]" value="{{value::change}}">
+        <input id="editingTemplateInput" class$="{{getClasses(validationResult)}}" type$="[[_getInputFieldType(_ie)]]"  value="[[value]]" on-input="_onInputChange">
 
         <px-tooltip
           for="editingTemplateInput"
@@ -67,6 +76,43 @@ Make number-renderer columns use ellipsis overflow:
 
         static get properties() {
           return {
+            /**
+             * Format used to display the number in the cell. Use a valid
+             * [numbro.js format string](http://numbrojs.com/format.html),
+             * or set to `null` to display the number exactly as it was passed
+             * by casing it to string.
+             */
+            displayFormat: {
+              type: String,
+              value: null
+            },
+
+            /**
+             * Changes how the number is displayed during localization.
+             * For valid formats and features, see: http://numbrojs.com/languages.html
+             */
+            displayCulture: {
+              type: String
+            },
+
+            /**
+             * Set to `true` if the number should be formatted as currency.
+             * Will use the `displayFormat` put parse the number as currency.
+             */
+            displayIsCurrency: {
+              type: String
+            },
+
+            /**
+             * Defines how to display 0 values.
+             * For valid formats and features, see: http://numbrojs.com/format.html
+             */
+            displayZeroFormat: {
+              type: String
+            },
+
+            _formattedValue: String,
+
             value: {
               type: Number
             },
@@ -84,7 +130,8 @@ Make number-renderer columns use ellipsis overflow:
 
         static get observers() {
           return [
-            '_valueObserver(value)'
+            '_valueObserver(value)',
+            '_rendererConfigChanged(column.rendererConfig, column.rendererConfig.*)'
           ];
         }
 
@@ -106,10 +153,6 @@ Make number-renderer columns use ellipsis overflow:
           };
         }
 
-        _getFormattedNumber(value) {
-          return value.toLocaleString();
-        }
-
         _getInputFieldType(ie) {
           if (ie) {
             return 'text';
@@ -119,9 +162,53 @@ Make number-renderer columns use ellipsis overflow:
         }
 
         _valueObserver(value) {
+          if (isNaN(Number(value))) {
+            // Can't be parsed to number, throw an error
+            console.error(`
+[px-data-grid-number-renderer]
+Expected a value that could be parsed to a number, but received a value that cannot be parsed.
+Column path: ${this.column.path}
+Unexpected value: ${value}
+            `.trim());
+            return;
+          }
           if (typeof value === 'string' && value.length > 0) {
             this.value = Number(value);
           }
+        }
+
+        _onInputChange(e) {
+          this.value = e.target.value;
+        }
+
+        _rendererConfigChanged(rendererConfig) {
+          if (rendererConfig) {
+            const updates = {};
+
+            if (rendererConfig.hasOwnProperty('displayFormat') && this.displayFormat !== rendererConfig.displayFormat) {
+              updates.displayFormat = rendererConfig.displayFormat;
+            }
+
+            if (rendererConfig.hasOwnProperty('displayCurrency') && this.displayCurrency !== rendererConfig.displayCurrency) {
+              updates.displayCurrency = rendererConfig.displayCurrency;
+            }
+
+            if (rendererConfig.hasOwnProperty('displayCulture') && this.displayCulture !== rendererConfig.displayCulture) {
+              updates.displayCulture = rendererConfig.displayCulture;
+            }
+
+            if (rendererConfig.hasOwnProperty('displayZeroFormat') && this.displayZeroFormat !== rendererConfig.displayZeroFormat) {
+              updates.displayZeroFormat = rendererConfig.displayZeroFormat;
+            }
+
+            if (Object.keys(updates).length) {
+              this.setProperties(updates);
+            }
+          }
+        }
+
+        _getDisplayFormat(format) {
+          return format === null ? 'NONE' : format;
         }
 
         getClasses(result) {

--- a/test/helpers.html
+++ b/test/helpers.html
@@ -99,6 +99,27 @@
       .value;
   }
 
+  /**
+   * Gets the `innerText` of a cell renderer. Useful for testing simple renderers
+   * that print out some formatted text.
+   *
+   * Compare with `getBodyCellContent()`, which gets the actual `value`
+   * property for a renderer, which is the data passed to it that may
+   * or may not be transformed to display to the user.
+   */
+  function getBodyCellText(grid, row, col) {
+    const rows = getRows(grid);
+    const cells = getRowCells(rows[row]);
+    const cell = cells[col];
+    return cell
+      .querySelector('slot')
+      .assignedNodes()[0]
+      .querySelector('px-data-grid-cell-content-wrapper')
+      .shadowRoot
+      .firstElementChild
+      .innerText;
+  }
+
   function getHeaderCell(grid, index) {
     return grid._vaadinGrid.$.header.querySelectorAll('[part~="cell"]')[index];
   }

--- a/test/px-data-grid-fixture.html
+++ b/test/px-data-grid-fixture.html
@@ -70,6 +70,7 @@
     <script src="change-data.js"></script>
     <script src="restore-layout.js"></script>
     <script src="items-without-ids.js"></script>
+    <script src="renderers.js"></script>
 
   </body>
 </html>

--- a/test/renderers.js
+++ b/test/renderers.js
@@ -1,0 +1,119 @@
+document.addEventListener('WebComponentsReady', () => {
+  describe('number renderer', () => {
+    let grid;
+    let _consoleErrorOriginal = null;
+    let consoleErrors = [];
+
+    beforeEach(done => {
+      grid = fixture('px-data-grid-fixture');
+
+      // Spy on console errors, taking over console.error so our tests don't fail.
+      // `sinon.spy` won't hijack the errors which causes our tests to fail,
+      // so this is a hand-rolled spy implementation.
+      _consoleErrorOriginal = console.error;
+      console.error = err => {
+        consoleErrors.push(err);
+      };
+
+      grid.columns = [
+        {
+          name: 'Name',
+          path: 'name'
+        },
+        {
+          name: 'Height',
+          path: 'height',
+          renderer: 'px-data-grid-number-renderer',
+          editable: true
+        },
+        {
+          name: 'Weight',
+          path: 'weight',
+          renderer: 'px-data-grid-number-renderer',
+          editable: true,
+          rendererConfig: {
+            displayFormat: '0,0'
+          }
+        },
+        {
+          name: 'Model',
+          path: 'model',
+          renderer: 'px-data-grid-number-renderer',
+          editable: true
+        }
+      ];
+
+      grid.tableData = [
+        {
+          name: 'GENERATOR 001',
+          height: 60.224,
+          weight: 190378.487,
+          model: '1934'
+        },
+        {
+          name: 'GENERATOR 002',
+          height: -63.13,
+          weight: 238712.03,
+          model: '1934.29'
+        },
+        {
+          name: 'GENERATOR 003',
+          height: 59.49,
+          weight: 0,
+          model: '099A'
+        },
+        {
+          name: 'GENERATOR 004',
+          height: 68,
+          weight: 478209.22,
+          model: ''
+         }
+      ];
+
+      Polymer.RenderStatus.afterNextRender(grid, () => {
+        setTimeout(() => { // IE11
+          done();
+        });
+      });
+    });
+
+    afterEach(() => {
+      // Reset console.error spy
+      console.error = _consoleErrorOriginal;
+      _consoleErrorOriginal = null;
+      consoleErrors = [];
+    });
+
+    it('displays numbers out without changing anything when rendererConfig.displayFormat is not defined', () => {
+      expect(getBodyCellText(grid, 0, 1) + '').to.equal('60.224');
+      expect(getBodyCellText(grid, 1, 1) + '').to.equal('-63.13');
+      expect(getBodyCellText(grid, 2, 1) + '').to.equal('59.49');
+      expect(getBodyCellText(grid, 3, 1) + '').to.equal('68');
+    });
+
+    it('formats numbers when rendererConfig.displayFormat is defined', () => {
+      expect(getBodyCellText(grid, 0, 2) + '').to.equal('190,378');
+      expect(getBodyCellText(grid, 1, 2) + '').to.equal('238,712');
+      expect(getBodyCellText(grid, 2, 2) + '').to.equal('0');
+      expect(getBodyCellText(grid, 3, 2) + '').to.equal('478,209');
+    });
+
+    it('displays strings that can be parsed to numbers', () => {
+      expect(getBodyCellText(grid, 0, 3) + '').to.equal('1934');
+      expect(getBodyCellText(grid, 1, 3) + '').to.equal('1934.29');
+    });
+
+    it('displays strings that cannot be parsed to numbers', () => {
+      expect(getBodyCellText(grid, 2, 3) + '').to.equal('099A');
+    });
+
+    it('does not coerce empty strings to `0`', () => {
+      expect(getBodyCellText(grid, 3, 3) + '').to.equal('');
+    });
+
+    it('throws an error but still displays values that cannot be parsed to a number', () => {
+      expect(consoleErrors.length).to.equal(1);
+      expect(consoleErrors[0]).to.match(/Expected a value that could be parsed to a number/);
+    });
+  });
+});


### PR DESCRIPTION
* When the px-data-grid-number-renderer is used for a column the
  developer can pass new rendererConfig options, including
  rendererConfig.displayFormat, which should be set to a valid
  numbro.js string used to format the number before it is displayed.
* Additional renderer options are exposed to customize how numbro.js
  formats the value. See the px-data-grid-number-renderer.html file
  for a full list.
* Throws an error when given a value that cannot be parsed
  to a number, but recovers and renders the value anyway.
* Adds new renderer tests to cover these cases.

See examples/renderer-number-config.html for a demo.

Supersedes #707. Final fixes for #624.