### PR TITLE
Fixing width for px-rangepicker in filter dialog

### DIFF
--- a/px-data-grid-filter-entity.html
+++ b/px-data-grid-filter-entity.html
@@ -57,7 +57,8 @@
             show-time-zone="abbreviatedText"
             show-field-titles
             from-moment="{{_dateFrom}}"
-            to-moment="{{_dateTo}}">
+            to-moment="{{_dateTo}}"
+            full-width>
           </px-rangepicker>
         </div>
       </template>

--- a/sass/px-data-grid-filter-entity.scss
+++ b/sass/px-data-grid-filter-entity.scss
@@ -31,3 +31,7 @@
 .labeled-text > * {
   width: 100%;
 }
+
+px-rangepicker {
+  --px-datetime-range-field-column-min-width: 0;
+}


### PR DESCRIPTION
Related to #630 

Using fullWidth property in order to make rangepickers span entire container width.  px-rangepicker has default min width of 250, so in order to get horizontal layout I’ve removed the min width.