### PR TITLE
Cancel tap and click events

### DIFF
--- a/px-data-grid-header-cell.html
+++ b/px-data-grid-header-cell.html
@@ -15,6 +15,7 @@
         hidden$="[[_dropdownHidden]]"
         on-px-dropdown-click="_dropdownItemClick"
         on-click="_dropdownClick"
+        on-tap="_dropdownClick"
         hoist>
       <px-icon slot="trigger" icon="px-nav:menu"></px-icon>
     </px-dropdown>


### PR DESCRIPTION
## What this fixes

In master with the latest px-dropdown the column header action menu dropdowns are not opening.

Steps to reproduce:

1. Pull latest from `master` branch
2. Wipe out bower_components and re-run `bower install`
3. Serve the grid
4. Open the docs page
5. Click on the column header action menu (three dots)

## What's going on

This fix solves an issue that appeared after [px-dropdown v4.7.1](https://github.com/PredixDev/px-dropdown/releases/tag/v4.7.1) was released.

Internally, px-dropdown is listening for an event called 'tap' on
its trigger. That's for legacy reasons. 'tap' is a Polymer 1.x
concept that was meant to normalize click events in touch
and mouse environments. To maintain compatability going forward
with px-dropdown it will continue to use the 'tap' event instead
of the 'click' event.

Because of this, the data grid is cancelling the click event but
allowing the tap event to bubble, which leads to the grid
opening the dropdown through property binding and the dropdown
toggling itself closed immediately.

This fix ensures that both the click and tap events are cancelled
and allows the dropdown to open correctly.